### PR TITLE
fix(docs): remove unnecessary information from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,10 @@ nox -s format
 
 To test changes, modify the `command` for the `analytics-mcp` entry in your
 `~/.gemini/settings.json` file so Gemini runs the server using your local
-source files:
+source files.
+
+Replace `PATH_TO_REPO` in the following snippet with the path where you cloned
+the repo:
 
 ```
       "command": "PATH_TO_REPO/.venv/bin/google-analytics-mcp",

--- a/README.md
+++ b/README.md
@@ -98,16 +98,10 @@ Here are some sample `gcloud` commands you might find useful:
     or [Gemini Code
     Assist](https://marketplace.visualstudio.com/items?itemName=Google.geminicodeassist)
 
-1.  Get a Gemini API key and set the `GEMINI_API_KEY` environment variable.
-
-    ```shell
-    export GEMINI_API_KEY=YOUR_GEMINI_API_KEY
-    ```
-
 1.  Create or edit the file at `~/.gemini/settings.json`, adding your server
     to the `mcpServers` list.
 
-    ```
+    ```json
     {
       "mcpServers": {
         "analytics-mcp": {
@@ -119,10 +113,6 @@ Here are some sample `gcloud` commands you might find useful:
             "google-analytics-mcp"
           ]
         }
-      },
-      "selectedAuthType": "gemini-api-key",
-      "fileFiltering": {
-        "enableRecursiveFileSearch": false
       }
     }
     ```
@@ -137,7 +127,7 @@ Here are some sample `gcloud` commands you might find useful:
     example with the full path to the ADC JSON file you always want to use for
     your MCP server.
 
-    ```
+    ```json
     {
       "mcpServers": {
         "analytics-mcp": {
@@ -149,14 +139,9 @@ Here are some sample `gcloud` commands you might find useful:
             "google-analytics-mcp"
           ],
           "env": {
-            "MCP_DEBUG": "true",
             "GOOGLE_APPLICATION_CREDENTIALS": "PATH_TO_ADC_JSON"
           }
         }
-      },
-      "selectedAuthType": "gemini-api-key",
-      "fileFiltering": {
-        "enableRecursiveFileSearch": false
       }
     }
     ```


### PR DESCRIPTION
- Removed additional settings from the Gemini settings snippets.
- Removed instructions about getting a Gemini API key. Both Gemini CLI and Gemini Code Assist automatically take the user through the various options for configuring Gemini at startup.