### PR TITLE
feat: add support for order_bys argument

### DIFF
--- a/analytics_mcp/tools/reporting/realtime.py
+++ b/analytics_mcp/tools/reporting/realtime.py
@@ -47,6 +47,7 @@ async def run_realtime_report(
     metrics: List[str],
     dimension_filter: Dict[str, Any] = None,
     metric_filter: Dict[str, Any] = None,
+    order_bys: List[Dict[str, Any]] = None,
     limit: int = None,
     offset: int = None,
     return_property_quota: bool = False,
@@ -77,6 +78,11 @@ async def run_realtime_report(
           `get_metrics` tools.
           For more information about the expected format of this argument, see
           the `run_report_metric_filter_hints` tool.
+        order_bys: A list of Data API OrderBy
+          (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/OrderBy)
+          objects to apply to the dimensions and metrics.
+          For more information about the expected format of this argument, see
+          the `run_report_order_bys_hints` tool.
         limit: The maximum number of rows to return in each response. Value must
           be a positive integer <= 250,000. Used to paginate through large
           reports, following the guide at
@@ -106,6 +112,11 @@ async def run_realtime_report(
 
     if metric_filter:
         request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    if order_bys:
+        request.order_bys = [
+            data_v1beta.OrderBy(order_by) for order_by in order_bys
+        ]
 
     if limit:
         request.limit = limit


### PR DESCRIPTION
Example of the (correct) arguments passed by Gemini when prompted for a top 10 analysis. Note the usage of `order_bys` *and* `limit` for efficiency.

```
Arguments
date_ranges:
[
  {
    "end_date": "today",
    "start_date": "5daysAgo"
  }
]
dimensions:
[
  "eventName"
]
limit:
10
metrics:
[
  "eventCount"
]
order_bys:
[
  {
    "desc": true,
    "metric": {
      "metric_name": "eventCount"
    }
  }
]
...
```