### PR TITLE
fix(deps): update dependency nox to v2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ env/
 venv/
 .venv/
 
+# pyenv
+.python-version
+
 # Test logs
 coverage.xml
 *sponge_log.xml

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -35,7 +35,9 @@ def _get_package_version_with_fallback():
 
 
 # Client information that adds a custom user agent to all API requests.
-_CLIENT_INFO = ClientInfo(user_agent=f"analytics-mcp/{_get_package_version_with_fallback()}")
+_CLIENT_INFO = ClientInfo(
+    user_agent=f"analytics-mcp/{_get_package_version_with_fallback()}"
+)
 
 # Read-only scope for Analytics Admin API and Analytics Data API.
 _READ_ONLY_ANALYTICS_SCOPE = (

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ import nox
 import os
 import pathlib
 
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 TEST_COMMAND = [
     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [project]
 name = "google-analytics-mcp"
 version = "0.1.0"
-requires-python = ">=3.9, <3.14"
+# Lower bound of 3.10 due to the 'mcp' dependency:
+# https://github.com/modelcontextprotocol/python-sdk/blob/main/pyproject.toml
+requires-python = ">=3.10, <3.14"
 license = "Apache-2.0"
 dependencies = [
     "google-analytics-data==0.18.19",
@@ -17,6 +19,6 @@ google-analytics-mcp = "analytics_mcp.server:run_server"
 [project.optional-dependencies]
 dev = [
     "black",
-    "nox >= 2020.12.31, < 2022.6"
+    "nox >=2025.5.1, <2026"
 ]
 


### PR DESCRIPTION
Removes Python 3.9 support as well, since the 'mcp' dependency only supports Python 3.10 or higher.