### PR TITLE
Adjust run_report date range schema that caused failure in Codex CLI

### DIFF
--- a/analytics_mcp/tools/reporting/core.py
+++ b/analytics_mcp/tools/reporting/core.py
@@ -81,7 +81,7 @@ def _run_report_description() -> str:
 
 async def run_report(
     property_id: int | str,
-    date_ranges: List[Dict[str, str]],
+    date_ranges: List[Dict[str, Any]],
     dimensions: List[str],
     metrics: List[str],
     dimension_filter: Dict[str, Any] = None,


### PR DESCRIPTION
As discussed in #40. I have verified it still works in Gemini CLI too