### PR TITLE
Add List Annotations Tools

### DIFF
--- a/analytics_mcp/tools/admin/info.py
+++ b/analytics_mcp/tools/admin/info.py
@@ -77,13 +77,15 @@ async def get_property_details(property_id: int | str) -> Dict[str, Any]:
 
 
 @mcp.tool(title="Gets property annotations for a property")
-async def list_property_annotations(property_id: int | str) -> List[Dict[str, Any]]:
+async def list_property_annotations(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
     """Returns annotations for a property.
-    
+
     Annotations are a feature that allows you to leave notes on GA4 for specific dates or periods.
     They are typically used to record service releases, marketing campaign launches or changes,
     and rapid traffic increases or decreases due to external factors.
-    
+
     Args:
         property_id: The Google Analytics property ID. Accepted formats are:
           - A number
@@ -92,8 +94,13 @@ async def list_property_annotations(property_id: int | str) -> List[Dict[str, An
     request = admin_v1alpha.ListReportingDataAnnotationsRequest(
         parent=construct_property_rn(property_id)
     )
-    annotations_pager = await create_admin_alpha_api_client().list_reporting_data_annotations(
-        request=request
+    annotations_pager = (
+        await create_admin_alpha_api_client().list_reporting_data_annotations(
+            request=request
+        )
     )
-    all_pages = [proto_to_dict(annotation_page) async for annotation_page in annotations_pager]
+    all_pages = [
+        proto_to_dict(annotation_page)
+        async for annotation_page in annotations_pager
+    ]
     return all_pages

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -71,7 +71,9 @@ def create_data_api_client() -> data_v1beta.BetaAnalyticsDataAsyncClient:
     )
 
 
-def create_admin_alpha_api_client() -> admin_v1alpha.AnalyticsAdminServiceAsyncClient:
+def create_admin_alpha_api_client() -> (
+    admin_v1alpha.AnalyticsAdminServiceAsyncClient
+):
     """Returns a properly configured Google Analytics Admin API (alpha) async client.
     Uses Application Default Credentials with read-only scope.
     """


### PR DESCRIPTION
## Overview
This pull request introduces the `list_property_annotations` tool, designed to retrieve a list of annotations set on a Google Analytics 4 (GA4) property. It utilizes the`properties.reportingDataAnnotations` method from the Google Analytics Data API v1alpha.

## Use Cases
This tool is intended for users who actively use GA4's annotation feature to log chronological events related to their website or business. For instance, it is ideal for scenarios where clients record information such as:

* Marketing campaign periods.
* Events that significantly impacted web traffic (e.g., press releases, major outages).
* Launch dates for new features or services.

By using this tool as a supplement to reporting workflows, analysts can easily correlate GA4 report data with real-world events. This enables a deeper and more accurate understanding of what drives fluctuations in metrics, helping to create more insightful and context-aware reports.