### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repo contains the source code for running a local
 [MCP](https://modelcontextprotocol.io) server that interacts with APIs for
 [Google Analytics](https://support.google.com/analytics).
 
+<a href="https://glama.ai/mcp/servers/@googleanalytics/google-analytics-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@googleanalytics/google-analytics-mcp/badge" alt="Google Analytics Server MCP server" />
+</a>
+
 Join the discussion and ask questions in the
 [🤖-analytics-mcp channel](https://discord.com/channels/971845904002871346/1398002598665257060)
 on Discord.


### PR DESCRIPTION
This PR adds a badge for the [Google Analytics MCP Server](https://glama.ai/mcp/servers/@googleanalytics/google-analytics-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@googleanalytics/google-analytics-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@googleanalytics/google-analytics-mcp/badge" alt="Google Analytics Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.