### PR TITLE
fix: convert non-boolean additionalProperties to boolean in tool schemas

### DIFF
--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -71,6 +71,30 @@ app = Server(
 )
 
 mcp_tools = [adk_to_mcp_tool_type(tool) for tool in tools]
+
+
+def _fix_additional_properties(schema: dict) -> None:
+    """Recursively convert non-boolean additionalProperties to boolean.
+
+    Some MCP clients (Claude Desktop, OpenAI Codex) expect
+    additionalProperties to be a boolean, not a schema object.
+    See https://github.com/googleanalytics/google-analytics-mcp/issues/40
+    """
+    if not isinstance(schema, dict):
+        return
+    if "additionalProperties" in schema and not isinstance(
+        schema["additionalProperties"], bool
+    ):
+        schema["additionalProperties"] = True
+    for value in schema.values():
+        if isinstance(value, dict):
+            _fix_additional_properties(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _fix_additional_properties(item)
+
+
 # Update the inputSchema for tools that do not have parameters.
 # TODO: This is a bug in the ADK and can be removed once it is fixed.
 # https://github.com/google/adk-python/issues/948
@@ -82,6 +106,8 @@ for tool in mcp_tools:
     for prop in tool.inputSchema.get("properties", {}).values():
         if "anyOf" in prop and prop.get("type") == "null":
             del prop["type"]
+    # Fix non-boolean additionalProperties that break some MCP clients
+    _fix_additional_properties(tool.inputSchema)
 
 
 @app.list_tools()


### PR DESCRIPTION
## Summary
- Fixes non-boolean `additionalProperties` in generated tool schemas that break MCP clients like Claude Desktop and OpenAI Codex
- The ADK generates `additionalProperties: {"type": "string"}` for `Dict[str, Any]` type hints, but some clients expect a boolean value
- Adds a recursive `_fix_additional_properties()` function in the existing schema post-processing step in `coordinator.py`

## Root Cause
Parameters typed as `Dict[str, Any]` (e.g., `date_ranges`, `dimension_filter`, `metric_filter`, `order_bys` in `run_report`) produce JSON Schema with `additionalProperties: {"type": "string"}` instead of `additionalProperties: true`. This causes:
- Claude Desktop: "No result received from client-side tool execution"
- OpenAI Codex: `Failed to convert MCP tool: invalid type: map, expected a boolean`

## Test plan
- [ ] Verify `run_report` tool schema has `additionalProperties: true` (boolean) instead of `{"type": "string"}`
- [ ] Verify Claude Desktop can successfully call `run_report`
- [ ] Verify OpenAI Codex can discover and use `run_report`

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)