### PR TITLE
fix: improve MCP schema compatibility and LLM guidance for reporting tools

### DIFF
--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -113,6 +113,12 @@ for tool in mcp_tools:
     # Ensure additionalProperties is compatible with all MCP clients
     sanitize_mcp_schema_properties(tool.inputSchema)
 
+    # Explicitly mark required fields for reporting tools to guide the LLM
+    if tool.name == "run_report":
+        tool.inputSchema["required"] = ["property_id", "date_ranges", "dimensions", "metrics"]
+    elif tool.name == "run_realtime_report":
+        tool.inputSchema["required"] = ["property_id", "dimensions", "metrics"]
+
 
 @app.list_tools()
 async def list_tools() -> list[mcp_types.Tool]:

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -109,13 +109,18 @@ for tool in mcp_tools:
     for prop in tool.inputSchema.get("properties", {}).values():
         if "anyOf" in prop and prop.get("type") == "null":
             del prop["type"]
-    
+
     # Ensure additionalProperties is compatible with all MCP clients
     sanitize_mcp_schema_properties(tool.inputSchema)
 
     # Explicitly mark required fields for reporting tools to guide the LLM
     if tool.name == "run_report":
-        tool.inputSchema["required"] = ["property_id", "date_ranges", "dimensions", "metrics"]
+        tool.inputSchema["required"] = [
+            "property_id",
+            "date_ranges",
+            "dimensions",
+            "metrics",
+        ]
     elif tool.name == "run_realtime_report":
         tool.inputSchema["required"] = ["property_id", "dimensions", "metrics"]
 

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -71,6 +71,33 @@ app = Server(
 )
 
 mcp_tools = [adk_to_mcp_tool_type(tool) for tool in tools]
+
+
+def sanitize_mcp_schema_properties(node: dict) -> None:
+    """Ensure additionalProperties is a boolean value to satisfy certain MCP clients.
+
+    This addresses issues with clients like Claude Desktop that fail when
+    additionalProperties is a schema object instead of a boolean.
+    """
+    if not isinstance(node, dict):
+        return
+
+    # Check and update the current node
+    if "additionalProperties" in node:
+        val = node["additionalProperties"]
+        if not isinstance(val, bool):
+            node["additionalProperties"] = True
+
+    # Traverse children
+    for key, child in node.items():
+        if isinstance(child, dict):
+            sanitize_mcp_schema_properties(child)
+        elif isinstance(child, list):
+            for element in child:
+                if isinstance(element, dict):
+                    sanitize_mcp_schema_properties(element)
+
+
 # Update the inputSchema for tools that do not have parameters.
 # TODO: This is a bug in the ADK and can be removed once it is fixed.
 # https://github.com/google/adk-python/issues/948
@@ -82,6 +109,9 @@ for tool in mcp_tools:
     for prop in tool.inputSchema.get("properties", {}).values():
         if "anyOf" in prop and prop.get("type") == "null":
             del prop["type"]
+    
+    # Ensure additionalProperties is compatible with all MCP clients
+    sanitize_mcp_schema_properties(tool.inputSchema)
 
 
 @app.list_tools()


### PR DESCRIPTION
This PR addresses two main issues with the Google Analytics MCP server:

   1. Client Compatibility: Some MCP clients (e.g., Claude Desktop) expect additionalProperties in the tool input schema to be a boolean value rather than an object. I've added a recursive sanitize_mcp_schema_properties function to ensure all additionalProperties fields are converted to booleans.
   2. LLM Guidance: To improve the reliability of tool calling for the run_report and run_realtime_report tools, I've explicitly marked essential fields as required in their schemas. This helps LLMs correctly identify the necessary arguments when generating tool calls.

  Changes:
   - Added sanitize_mcp_schema_properties utility to analytics_mcp/coordinator.py.
   - Applied schema sanitization to all MCP tools.
   - Explicitly defined required fields for run_report and run_realtime_report tools.