### PR TITLE
fix: resolve Windows stdio deadlocks caused by grpc.aio and google.auth

### DIFF
--- a/analytics_mcp/tools/admin/info.py
+++ b/analytics_mcp/tools/admin/info.py
@@ -14,11 +14,15 @@
 
 """Tools for gathering Google Analytics account and property information."""
 
+import asyncio
+import sys
 from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
+    create_admin_api_client,
     create_admin_api_client_sync,
+    create_admin_alpha_api_client,
     create_admin_alpha_api_client_sync,
     proto_to_dict,
 )
@@ -27,13 +31,16 @@ from google.analytics import admin_v1beta, admin_v1alpha
 
 async def get_account_summaries() -> List[Dict[str, Any]]:
     """Retrieves information about the user's Google Analytics accounts and properties."""
-    import asyncio
-    def _fetch():
-        client = create_admin_api_client_sync()
-        summary_pager = client.list_account_summaries()
-        return [proto_to_dict(summary_page) for summary_page in summary_pager]
-    
-    return await asyncio.to_thread(_fetch)
+    if sys.platform == "win32":
+        def _fetch():
+            client = create_admin_api_client_sync()
+            summary_pager = client.list_account_summaries()
+            return [proto_to_dict(summary_page) for summary_page in summary_pager]
+        return await asyncio.to_thread(_fetch)
+
+    client = create_admin_api_client()
+    summary_pager = await client.list_account_summaries()
+    return [proto_to_dict(summary_page) for summary_page in summary_pager]
 
 
 async def list_google_ads_links(property_id: int | str) -> List[Dict[str, Any]]:
@@ -44,17 +51,22 @@ async def list_google_ads_links(property_id: int | str) -> List[Dict[str, Any]]:
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    import asyncio
-    def _fetch():
-        request = admin_v1beta.ListGoogleAdsLinksRequest(
-            parent=construct_property_rn(property_id)
-        )
-        links_pager = create_admin_api_client_sync().list_google_ads_links(
-            request=request
-        )
-        return [proto_to_dict(link_page) for link_page in links_pager]
-        
-    return await asyncio.to_thread(_fetch)
+    request = admin_v1beta.ListGoogleAdsLinksRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    if sys.platform == "win32":
+        def _fetch():
+            links_pager = create_admin_api_client_sync().list_google_ads_links(
+                request=request
+            )
+            return [proto_to_dict(link_page) for link_page in links_pager]
+        return await asyncio.to_thread(_fetch)
+
+    links_pager = await create_admin_api_client().list_google_ads_links(
+        request=request
+    )
+    return [proto_to_dict(link_page) for link_page in links_pager]
 
 
 async def get_property_details(property_id: int | str) -> Dict[str, Any]:
@@ -64,16 +76,20 @@ async def get_property_details(property_id: int | str) -> Dict[str, Any]:
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    import asyncio
-    def _fetch():
-        client = create_admin_api_client_sync()
-        request = admin_v1beta.GetPropertyRequest(
-            name=construct_property_rn(property_id)
-        )
-        response = client.get_property(request=request)
-        return proto_to_dict(response)
-        
-    return await asyncio.to_thread(_fetch)
+    request = admin_v1beta.GetPropertyRequest(
+        name=construct_property_rn(property_id)
+    )
+
+    if sys.platform == "win32":
+        def _fetch():
+            client = create_admin_api_client_sync()
+            response = client.get_property(request=request)
+            return proto_to_dict(response)
+        return await asyncio.to_thread(_fetch)
+
+    client = create_admin_api_client()
+    response = await client.get_property(request=request)
+    return proto_to_dict(response)
 
 
 async def list_property_annotations(
@@ -90,14 +106,19 @@ async def list_property_annotations(
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    import asyncio
-    def _fetch():
-        request = admin_v1alpha.ListReportingDataAnnotationsRequest(
-            parent=construct_property_rn(property_id)
-        )
-        annotations_pager = create_admin_alpha_api_client_sync().list_reporting_data_annotations(
-            request=request
-        )
-        return [proto_to_dict(annotation_page) for annotation_page in annotations_pager]
-        
-    return await asyncio.to_thread(_fetch)
+    request = admin_v1alpha.ListReportingDataAnnotationsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    if sys.platform == "win32":
+        def _fetch():
+            annotations_pager = create_admin_alpha_api_client_sync().list_reporting_data_annotations(
+                request=request
+            )
+            return [proto_to_dict(annotation_page) for annotation_page in annotations_pager]
+        return await asyncio.to_thread(_fetch)
+
+    annotations_pager = await create_admin_alpha_api_client().list_reporting_data_annotations(
+        request=request
+    )
+    return [proto_to_dict(annotation_page) for annotation_page in annotations_pager]

--- a/analytics_mcp/tools/admin/info.py
+++ b/analytics_mcp/tools/admin/info.py
@@ -18,8 +18,8 @@ from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
-    create_admin_api_client,
-    create_admin_alpha_api_client,
+    create_admin_api_client_sync,
+    create_admin_alpha_api_client_sync,
     proto_to_dict,
 )
 from google.analytics import admin_v1beta, admin_v1alpha
@@ -27,14 +27,13 @@ from google.analytics import admin_v1beta, admin_v1alpha
 
 async def get_account_summaries() -> List[Dict[str, Any]]:
     """Retrieves information about the user's Google Analytics accounts and properties."""
-
-    # Uses an async list comprehension so the pager returned by
-    # list_account_summaries retrieves all pages.
-    summary_pager = await create_admin_api_client().list_account_summaries()
-    all_pages = [
-        proto_to_dict(summary_page) async for summary_page in summary_pager
-    ]
-    return all_pages
+    import asyncio
+    def _fetch():
+        client = create_admin_api_client_sync()
+        summary_pager = client.list_account_summaries()
+        return [proto_to_dict(summary_page) for summary_page in summary_pager]
+    
+    return await asyncio.to_thread(_fetch)
 
 
 async def list_google_ads_links(property_id: int | str) -> List[Dict[str, Any]]:
@@ -45,16 +44,17 @@ async def list_google_ads_links(property_id: int | str) -> List[Dict[str, Any]]:
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    request = admin_v1beta.ListGoogleAdsLinksRequest(
-        parent=construct_property_rn(property_id)
-    )
-    # Uses an async list comprehension so the pager returned by
-    # list_google_ads_links retrieves all pages.
-    links_pager = await create_admin_api_client().list_google_ads_links(
-        request=request
-    )
-    all_pages = [proto_to_dict(link_page) async for link_page in links_pager]
-    return all_pages
+    import asyncio
+    def _fetch():
+        request = admin_v1beta.ListGoogleAdsLinksRequest(
+            parent=construct_property_rn(property_id)
+        )
+        links_pager = create_admin_api_client_sync().list_google_ads_links(
+            request=request
+        )
+        return [proto_to_dict(link_page) for link_page in links_pager]
+        
+    return await asyncio.to_thread(_fetch)
 
 
 async def get_property_details(property_id: int | str) -> Dict[str, Any]:
@@ -64,12 +64,16 @@ async def get_property_details(property_id: int | str) -> Dict[str, Any]:
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    client = create_admin_api_client()
-    request = admin_v1beta.GetPropertyRequest(
-        name=construct_property_rn(property_id)
-    )
-    response = await client.get_property(request=request)
-    return proto_to_dict(response)
+    import asyncio
+    def _fetch():
+        client = create_admin_api_client_sync()
+        request = admin_v1beta.GetPropertyRequest(
+            name=construct_property_rn(property_id)
+        )
+        response = client.get_property(request=request)
+        return proto_to_dict(response)
+        
+    return await asyncio.to_thread(_fetch)
 
 
 async def list_property_annotations(
@@ -86,16 +90,14 @@ async def list_property_annotations(
           - A number
           - A string consisting of 'properties/' followed by a number
     """
-    request = admin_v1alpha.ListReportingDataAnnotationsRequest(
-        parent=construct_property_rn(property_id)
-    )
-    annotations_pager = (
-        await create_admin_alpha_api_client().list_reporting_data_annotations(
+    import asyncio
+    def _fetch():
+        request = admin_v1alpha.ListReportingDataAnnotationsRequest(
+            parent=construct_property_rn(property_id)
+        )
+        annotations_pager = create_admin_alpha_api_client_sync().list_reporting_data_annotations(
             request=request
         )
-    )
-    all_pages = [
-        proto_to_dict(annotation_page)
-        async for annotation_page in annotations_pager
-    ]
-    return all_pages
+        return [proto_to_dict(annotation_page) for annotation_page in annotations_pager]
+        
+    return await asyncio.to_thread(_fetch)

--- a/analytics_mcp/tools/reporting/core.py
+++ b/analytics_mcp/tools/reporting/core.py
@@ -14,6 +14,8 @@
 
 """Tools for running core reports using the Data API."""
 
+import asyncio
+import sys
 from typing import Any, Dict, List
 
 from analytics_mcp.tools.reporting.metadata import (
@@ -24,6 +26,7 @@ from analytics_mcp.tools.reporting.metadata import (
 )
 from analytics_mcp.tools.utils import (
     construct_property_rn,
+    create_data_api_client,
     create_data_api_client_sync,
     proto_to_dict,
 )
@@ -137,40 +140,42 @@ async def run_report(
           report uses the property's default currency.
         return_property_quota: Whether to return property quota in the response.
     """
-    import asyncio
-    def _fetch():
-        request = data_v1beta.RunReportRequest(
-            property=construct_property_rn(property_id),
-            dimensions=[
-                data_v1beta.Dimension(name=dimension) for dimension in dimensions
-            ],
-            metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
-            date_ranges=[data_v1beta.DateRange(dr) for dr in date_ranges],
-            return_property_quota=return_property_quota,
+    request = data_v1beta.RunReportRequest(
+        property=construct_property_rn(property_id),
+        dimensions=[
+            data_v1beta.Dimension(name=dimension) for dimension in dimensions
+        ],
+        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+        date_ranges=[data_v1beta.DateRange(dr) for dr in date_ranges],
+        return_property_quota=return_property_quota,
+    )
+
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
         )
 
-        if dimension_filter:
-            request.dimension_filter = data_v1beta.FilterExpression(
-                dimension_filter
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    if order_bys:
+        request.order_bys = [
+            data_v1beta.OrderBy(order_by) for order_by in order_bys
+        ]
+
+    if limit:
+        request.limit = limit
+    if offset:
+        request.offset = offset
+    if currency_code:
+        request.currency_code = currency_code
+
+    if sys.platform == "win32":
+        def _fetch():
+            return proto_to_dict(
+                create_data_api_client_sync().run_report(request)
             )
+        return await asyncio.to_thread(_fetch)
 
-        if metric_filter:
-            request.metric_filter = data_v1beta.FilterExpression(metric_filter)
-
-        if order_bys:
-            request.order_bys = [
-                data_v1beta.OrderBy(order_by) for order_by in order_bys
-            ]
-
-        if limit:
-            request.limit = limit
-        if offset:
-            request.offset = offset
-        if currency_code:
-            request.currency_code = currency_code
-
-        response = create_data_api_client_sync().run_report(request)
-
-        return proto_to_dict(response)
-        
-    return await asyncio.to_thread(_fetch)
+    response = await create_data_api_client().run_report(request)
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/core.py
+++ b/analytics_mcp/tools/reporting/core.py
@@ -24,7 +24,7 @@ from analytics_mcp.tools.reporting.metadata import (
 )
 from analytics_mcp.tools.utils import (
     construct_property_rn,
-    create_data_api_client,
+    create_data_api_client_sync,
     proto_to_dict,
 )
 from google.analytics import data_v1beta
@@ -137,36 +137,40 @@ async def run_report(
           report uses the property's default currency.
         return_property_quota: Whether to return property quota in the response.
     """
-    request = data_v1beta.RunReportRequest(
-        property=construct_property_rn(property_id),
-        dimensions=[
-            data_v1beta.Dimension(name=dimension) for dimension in dimensions
-        ],
-        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
-        date_ranges=[data_v1beta.DateRange(dr) for dr in date_ranges],
-        return_property_quota=return_property_quota,
-    )
-
-    if dimension_filter:
-        request.dimension_filter = data_v1beta.FilterExpression(
-            dimension_filter
+    import asyncio
+    def _fetch():
+        request = data_v1beta.RunReportRequest(
+            property=construct_property_rn(property_id),
+            dimensions=[
+                data_v1beta.Dimension(name=dimension) for dimension in dimensions
+            ],
+            metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+            date_ranges=[data_v1beta.DateRange(dr) for dr in date_ranges],
+            return_property_quota=return_property_quota,
         )
 
-    if metric_filter:
-        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+        if dimension_filter:
+            request.dimension_filter = data_v1beta.FilterExpression(
+                dimension_filter
+            )
 
-    if order_bys:
-        request.order_bys = [
-            data_v1beta.OrderBy(order_by) for order_by in order_bys
-        ]
+        if metric_filter:
+            request.metric_filter = data_v1beta.FilterExpression(metric_filter)
 
-    if limit:
-        request.limit = limit
-    if offset:
-        request.offset = offset
-    if currency_code:
-        request.currency_code = currency_code
+        if order_bys:
+            request.order_bys = [
+                data_v1beta.OrderBy(order_by) for order_by in order_bys
+            ]
 
-    response = await create_data_api_client().run_report(request)
+        if limit:
+            request.limit = limit
+        if offset:
+            request.offset = offset
+        if currency_code:
+            request.currency_code = currency_code
 
-    return proto_to_dict(response)
+        response = create_data_api_client_sync().run_report(request)
+
+        return proto_to_dict(response)
+        
+    return await asyncio.to_thread(_fetch)

--- a/analytics_mcp/tools/reporting/metadata.py
+++ b/analytics_mcp/tools/reporting/metadata.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
-    create_data_api_client,
+    create_data_api_client_sync,
     proto_to_dict,
     proto_to_json,
 )
@@ -319,20 +319,23 @@ async def get_custom_dimensions_and_metrics(
           - A string consisting of 'properties/' followed by a number
 
     """
-    metadata = await create_data_api_client().get_metadata(
-        name=f"{construct_property_rn(property_id)}/metadata"
-    )
-    custom_metrics = [
-        proto_to_dict(metric)
-        for metric in metadata.metrics
-        if metric.custom_definition
-    ]
-    custom_dimensions = [
-        proto_to_dict(dimension)
-        for dimension in metadata.dimensions
-        if dimension.custom_definition
-    ]
-    return {
-        "custom_dimensions": custom_dimensions,
-        "custom_metrics": custom_metrics,
-    }
+    import asyncio
+    def _fetch():
+        metadata = create_data_api_client_sync().get_metadata(
+            name=f"{construct_property_rn(property_id)}/metadata"
+        )
+        custom_metrics = [
+            proto_to_dict(metric)
+            for metric in metadata.metrics
+            if metric.custom_definition
+        ]
+        custom_dimensions = [
+            proto_to_dict(dimension)
+            for dimension in metadata.dimensions
+            if dimension.custom_definition
+        ]
+        return {
+            "custom_dimensions": custom_dimensions,
+            "custom_metrics": custom_metrics,
+        }
+    return await asyncio.to_thread(_fetch)

--- a/analytics_mcp/tools/reporting/metadata.py
+++ b/analytics_mcp/tools/reporting/metadata.py
@@ -14,10 +14,13 @@
 
 """Metadata to provide context and hints for reporting tools."""
 
+import asyncio
+import sys
 from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
+    create_data_api_client,
     create_data_api_client_sync,
     proto_to_dict,
     proto_to_json,
@@ -319,23 +322,41 @@ async def get_custom_dimensions_and_metrics(
           - A string consisting of 'properties/' followed by a number
 
     """
-    import asyncio
-    def _fetch():
-        metadata = create_data_api_client_sync().get_metadata(
-            name=f"{construct_property_rn(property_id)}/metadata"
-        )
-        custom_metrics = [
-            proto_to_dict(metric)
-            for metric in metadata.metrics
-            if metric.custom_definition
-        ]
-        custom_dimensions = [
-            proto_to_dict(dimension)
-            for dimension in metadata.dimensions
-            if dimension.custom_definition
-        ]
-        return {
-            "custom_dimensions": custom_dimensions,
-            "custom_metrics": custom_metrics,
-        }
-    return await asyncio.to_thread(_fetch)
+    if sys.platform == "win32":
+        def _fetch():
+            metadata = create_data_api_client_sync().get_metadata(
+                name=f"{construct_property_rn(property_id)}/metadata"
+            )
+            custom_metrics = [
+                proto_to_dict(metric)
+                for metric in metadata.metrics
+                if metric.custom_definition
+            ]
+            custom_dimensions = [
+                proto_to_dict(dimension)
+                for dimension in metadata.dimensions
+                if dimension.custom_definition
+            ]
+            return {
+                "custom_dimensions": custom_dimensions,
+                "custom_metrics": custom_metrics,
+            }
+        return await asyncio.to_thread(_fetch)
+
+    metadata = await create_data_api_client().get_metadata(
+        name=f"{construct_property_rn(property_id)}/metadata"
+    )
+    custom_metrics = [
+        proto_to_dict(metric)
+        for metric in metadata.metrics
+        if metric.custom_definition
+    ]
+    custom_dimensions = [
+        proto_to_dict(dimension)
+        for dimension in metadata.dimensions
+        if dimension.custom_definition
+    ]
+    return {
+        "custom_dimensions": custom_dimensions,
+        "custom_metrics": custom_metrics,
+    }

--- a/analytics_mcp/tools/reporting/realtime.py
+++ b/analytics_mcp/tools/reporting/realtime.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
-    create_data_api_client,
+    create_data_api_client_sync,
     proto_to_dict,
 )
 from analytics_mcp.tools.reporting.metadata import (
@@ -130,32 +130,36 @@ async def run_realtime_report(
           https://developers.google.com/analytics/devguides/reporting/data/v1/basics#pagination.
         return_property_quota: Whether to return realtime property quota in the response.
     """
-    request = data_v1beta.RunRealtimeReportRequest(
-        property=construct_property_rn(property_id),
-        dimensions=[
-            data_v1beta.Dimension(name=dimension) for dimension in dimensions
-        ],
-        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
-        return_property_quota=return_property_quota,
-    )
-
-    if dimension_filter:
-        request.dimension_filter = data_v1beta.FilterExpression(
-            dimension_filter
+    import asyncio
+    def _fetch():
+        request = data_v1beta.RunRealtimeReportRequest(
+            property=construct_property_rn(property_id),
+            dimensions=[
+                data_v1beta.Dimension(name=dimension) for dimension in dimensions
+            ],
+            metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+            return_property_quota=return_property_quota,
         )
 
-    if metric_filter:
-        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+        if dimension_filter:
+            request.dimension_filter = data_v1beta.FilterExpression(
+                dimension_filter
+            )
 
-    if order_bys:
-        request.order_bys = [
-            data_v1beta.OrderBy(order_by) for order_by in order_bys
-        ]
+        if metric_filter:
+            request.metric_filter = data_v1beta.FilterExpression(metric_filter)
 
-    if limit:
-        request.limit = limit
-    if offset:
-        request.offset = offset
+        if order_bys:
+            request.order_bys = [
+                data_v1beta.OrderBy(order_by) for order_by in order_bys
+            ]
 
-    response = await create_data_api_client().run_realtime_report(request)
-    return proto_to_dict(response)
+        if limit:
+            request.limit = limit
+        if offset:
+            request.offset = offset
+
+        response = create_data_api_client_sync().run_realtime_report(request)
+        return proto_to_dict(response)
+        
+    return await asyncio.to_thread(_fetch)

--- a/analytics_mcp/tools/reporting/realtime.py
+++ b/analytics_mcp/tools/reporting/realtime.py
@@ -14,10 +14,13 @@
 
 """Tools for running realtime reports using the Data API."""
 
+import asyncio
+import sys
 from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
+    create_data_api_client,
     create_data_api_client_sync,
     proto_to_dict,
 )
@@ -130,36 +133,39 @@ async def run_realtime_report(
           https://developers.google.com/analytics/devguides/reporting/data/v1/basics#pagination.
         return_property_quota: Whether to return realtime property quota in the response.
     """
-    import asyncio
-    def _fetch():
-        request = data_v1beta.RunRealtimeReportRequest(
-            property=construct_property_rn(property_id),
-            dimensions=[
-                data_v1beta.Dimension(name=dimension) for dimension in dimensions
-            ],
-            metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
-            return_property_quota=return_property_quota,
+    request = data_v1beta.RunRealtimeReportRequest(
+        property=construct_property_rn(property_id),
+        dimensions=[
+            data_v1beta.Dimension(name=dimension) for dimension in dimensions
+        ],
+        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+        return_property_quota=return_property_quota,
+    )
+
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
         )
 
-        if dimension_filter:
-            request.dimension_filter = data_v1beta.FilterExpression(
-                dimension_filter
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    if order_bys:
+        request.order_bys = [
+            data_v1beta.OrderBy(order_by) for order_by in order_bys
+        ]
+
+    if limit:
+        request.limit = limit
+    if offset:
+        request.offset = offset
+
+    if sys.platform == "win32":
+        def _fetch():
+            return proto_to_dict(
+                create_data_api_client_sync().run_realtime_report(request)
             )
+        return await asyncio.to_thread(_fetch)
 
-        if metric_filter:
-            request.metric_filter = data_v1beta.FilterExpression(metric_filter)
-
-        if order_bys:
-            request.order_bys = [
-                data_v1beta.OrderBy(order_by) for order_by in order_bys
-            ]
-
-        if limit:
-            request.limit = limit
-        if offset:
-            request.offset = offset
-
-        response = create_data_api_client_sync().run_realtime_report(request)
-        return proto_to_dict(response)
-        
-    return await asyncio.to_thread(_fetch)
+    response = await create_data_api_client().run_realtime_report(request)
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -47,37 +47,41 @@ _READ_ONLY_ANALYTICS_SCOPE = (
 
 def _create_credentials() -> google.auth.credentials.Credentials:
     """Returns Application Default Credentials with read-only scope."""
-    credentials, _ = google.auth.default(scopes=[_READ_ONLY_ANALYTICS_SCOPE])
-    return credentials
+    import sys
+    import os
+    import google.oauth2.credentials
+    print("_create_credentials started", file=sys.stderr)
+    try:
+        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if path and os.path.exists(path):
+            print(f"Loading credentials directly from {path}", file=sys.stderr)
+            credentials = google.oauth2.credentials.Credentials.from_authorized_user_file(path, scopes=[_READ_ONLY_ANALYTICS_SCOPE])
+            print("Credentials loaded successfully from file", file=sys.stderr)
+            return credentials
+        else:
+            print("GOOGLE_APPLICATION_CREDENTIALS not found, falling back to default", file=sys.stderr)
+            credentials, _ = google.auth.default(scopes=[_READ_ONLY_ANALYTICS_SCOPE])
+            print("google.auth.default finished", file=sys.stderr)
+            return credentials
+    except Exception as e:
+        print(f"google.auth.default failed: {e}", file=sys.stderr)
+        raise
 
 
-def create_admin_api_client() -> admin_v1beta.AnalyticsAdminServiceAsyncClient:
-    """Returns a properly configured Google Analytics Admin API async client.
-
-    Uses Application Default Credentials with read-only scope.
-    """
-    return admin_v1beta.AnalyticsAdminServiceAsyncClient(
+def create_admin_api_client_sync() -> admin_v1beta.AnalyticsAdminServiceClient:
+    return admin_v1beta.AnalyticsAdminServiceClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 
 
-def create_data_api_client() -> data_v1beta.BetaAnalyticsDataAsyncClient:
-    """Returns a properly configured Google Analytics Data API async client.
-
-    Uses Application Default Credentials with read-only scope.
-    """
-    return data_v1beta.BetaAnalyticsDataAsyncClient(
+def create_data_api_client_sync() -> data_v1beta.BetaAnalyticsDataClient:
+    return data_v1beta.BetaAnalyticsDataClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 
 
-def create_admin_alpha_api_client() -> (
-    admin_v1alpha.AnalyticsAdminServiceAsyncClient
-):
-    """Returns a properly configured Google Analytics Admin API (alpha) async client.
-    Uses Application Default Credentials with read-only scope.
-    """
-    return admin_v1alpha.AnalyticsAdminServiceAsyncClient(
+def create_admin_alpha_api_client_sync() -> admin_v1alpha.AnalyticsAdminServiceClient:
+    return admin_v1alpha.AnalyticsAdminServiceClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -14,12 +14,15 @@
 
 """Common utilities used by the MCP server."""
 
+import os
+import sys
 from typing import Any, Dict
 
 from google.analytics import admin_v1beta, data_v1beta, admin_v1alpha
 from google.api_core.gapic_v1.client_info import ClientInfo
 from importlib import metadata
 import google.auth
+import google.oauth2.credentials
 import proto
 
 
@@ -46,42 +49,85 @@ _READ_ONLY_ANALYTICS_SCOPE = (
 
 
 def _create_credentials() -> google.auth.credentials.Credentials:
-    """Returns Application Default Credentials with read-only scope."""
-    import sys
-    import os
-    import google.oauth2.credentials
-    print("_create_credentials started", file=sys.stderr)
-    try:
+    """Returns Application Default Credentials with read-only scope.
+
+    On Windows, prefers loading credentials directly from the file specified
+    by GOOGLE_APPLICATION_CREDENTIALS to avoid subprocess spawning, which can
+    interfere with the MCP server's stdio transport.
+    """
+    if sys.platform == "win32":
         path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if path and os.path.exists(path):
-            print(f"Loading credentials directly from {path}", file=sys.stderr)
-            credentials = google.oauth2.credentials.Credentials.from_authorized_user_file(path, scopes=[_READ_ONLY_ANALYTICS_SCOPE])
-            print("Credentials loaded successfully from file", file=sys.stderr)
-            return credentials
-        else:
-            print("GOOGLE_APPLICATION_CREDENTIALS not found, falling back to default", file=sys.stderr)
-            credentials, _ = google.auth.default(scopes=[_READ_ONLY_ANALYTICS_SCOPE])
-            print("google.auth.default finished", file=sys.stderr)
-            return credentials
-    except Exception as e:
-        print(f"google.auth.default failed: {e}", file=sys.stderr)
-        raise
+            return google.oauth2.credentials.Credentials.from_authorized_user_file(
+                path, scopes=[_READ_ONLY_ANALYTICS_SCOPE]
+            )
+    credentials, _ = google.auth.default(scopes=[_READ_ONLY_ANALYTICS_SCOPE])
+    return credentials
 
 
 def create_admin_api_client_sync() -> admin_v1beta.AnalyticsAdminServiceClient:
+    """Returns a properly configured Google Analytics Admin API sync client.
+
+    Uses Application Default Credentials with read-only scope.
+    On Windows, this sync client is used instead of the async variant to
+    avoid grpc.aio event loop conflicts with the MCP stdio transport.
+    """
     return admin_v1beta.AnalyticsAdminServiceClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 
 
 def create_data_api_client_sync() -> data_v1beta.BetaAnalyticsDataClient:
+    """Returns a properly configured Google Analytics Data API sync client.
+
+    Uses Application Default Credentials with read-only scope.
+    On Windows, this sync client is used instead of the async variant to
+    avoid grpc.aio event loop conflicts with the MCP stdio transport.
+    """
     return data_v1beta.BetaAnalyticsDataClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 
 
 def create_admin_alpha_api_client_sync() -> admin_v1alpha.AnalyticsAdminServiceClient:
+    """Returns a properly configured Google Analytics Admin API (alpha) sync client.
+
+    Uses Application Default Credentials with read-only scope.
+    On Windows, this sync client is used instead of the async variant to
+    avoid grpc.aio event loop conflicts with the MCP stdio transport.
+    """
     return admin_v1alpha.AnalyticsAdminServiceClient(
+        client_info=_CLIENT_INFO, credentials=_create_credentials()
+    )
+
+
+def create_admin_api_client() -> admin_v1beta.AnalyticsAdminServiceAsyncClient:
+    """Returns a properly configured Google Analytics Admin API async client.
+
+    Uses Application Default Credentials with read-only scope.
+    """
+    return admin_v1beta.AnalyticsAdminServiceAsyncClient(
+        client_info=_CLIENT_INFO, credentials=_create_credentials()
+    )
+
+
+def create_data_api_client() -> data_v1beta.BetaAnalyticsDataAsyncClient:
+    """Returns a properly configured Google Analytics Data API async client.
+
+    Uses Application Default Credentials with read-only scope.
+    """
+    return data_v1beta.BetaAnalyticsDataAsyncClient(
+        client_info=_CLIENT_INFO, credentials=_create_credentials()
+    )
+
+
+def create_admin_alpha_api_client() -> (
+    admin_v1alpha.AnalyticsAdminServiceAsyncClient
+):
+    """Returns a properly configured Google Analytics Admin API (alpha) async client.
+    Uses Application Default Credentials with read-only scope.
+    """
+    return admin_v1alpha.AnalyticsAdminServiceAsyncClient(
         client_info=_CLIENT_INFO, credentials=_create_credentials()
     )
 


### PR DESCRIPTION
## Description

This PR resolves a critical starvation/deadlock issue when running the MCP server over standard I/O (stdio) on Windows.

### The Problem
1. Using google.auth.default() spawns subprocesses to resolve credentials, which can interfere with the standard I/O pipes used by the MCP JSON-RPC protocol.
2. The grpc.aio async clients are known to cause event loop stalls and thread exhaustion on Windows when run concurrently with standard I/O streams.

### The Solution
1. Updated client factory methods in utils.py to use the synchronous AnalyticsAdminServiceClient and BetaAnalyticsDataClient.
2. Offloaded blocking API calls inside the MCP tool functions (admin/info.py, reporting/*.py) using asyncio.to_thread(_fetch) to maintain non-blocking concurrency.
3. Added explicit file-loading logic (Credentials.from_authorized_user_file) in utils.py to bypass subprocess spawning during authentication.

This has been tested locally with Google Antigravity on Windows 11 with the analytics-mcp connected to a Gemini Code Assist instance, resulting in perfect stability where it previously hung indefinitely.