### PR TITLE
fix: reduce token count of get_account_summaries

### DIFF
--- a/analytics_mcp/tools/admin/info.py
+++ b/analytics_mcp/tools/admin/info.py
@@ -14,7 +14,7 @@
 
 """Tools for gathering Google Analytics account and property information."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from analytics_mcp.tools.utils import (
     construct_property_rn,
@@ -24,9 +24,39 @@ from analytics_mcp.tools.utils import (
 )
 from google.analytics import admin_v1beta, admin_v1alpha
 
+# Fields stripped from account summaries to reduce token count.
+_ACCOUNT_STRIP_FIELDS = {"name"}
+_PROPERTY_STRIP_FIELDS = {"name", "parent", "property_type"}
 
-async def get_account_summaries() -> List[Dict[str, Any]]:
-    """Retrieves information about the user's Google Analytics accounts and properties."""
+
+def _strip_account_summary(account: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove redundant fields from an account summary and its properties."""
+    cleaned = {k: v for k, v in account.items() if k not in _ACCOUNT_STRIP_FIELDS}
+    if "property_summaries" in cleaned:
+        cleaned["property_summaries"] = [
+            {k: v for k, v in prop.items() if k not in _PROPERTY_STRIP_FIELDS}
+            for prop in cleaned["property_summaries"]
+        ]
+    return cleaned
+
+
+async def get_account_summaries(
+    query: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Retrieves the user's Google Analytics accounts and properties.
+
+    Returns a compact representation with redundant fields (name, parent,
+    property_type) stripped to reduce token usage. Each account keeps its
+    ``account`` resource-name and ``display_name``; each property keeps its
+    ``property`` resource-name and ``display_name``.
+
+    Args:
+        query: Optional case-insensitive search string. When provided, only
+            accounts or properties whose display name contains the query are
+            returned. An account is included if its own display name matches
+            **or** any of its properties match; non-matching properties on an
+            otherwise-matching account are still filtered out.
+    """
 
     # Uses an async list comprehension so the pager returned by
     # list_account_summaries retrieves all pages.
@@ -34,6 +64,29 @@ async def get_account_summaries() -> List[Dict[str, Any]]:
     all_pages = [
         proto_to_dict(summary_page) async for summary_page in summary_pager
     ]
+
+    # Strip redundant fields.
+    all_pages = [_strip_account_summary(s) for s in all_pages]
+
+    # Apply optional display-name filter.
+    if query:
+        q = query.lower()
+        filtered = []
+        for account in all_pages:
+            acct_match = q in account.get("display_name", "").lower()
+            matching_props = [
+                p
+                for p in account.get("property_summaries", [])
+                if q in p.get("display_name", "").lower()
+            ]
+            if acct_match or matching_props:
+                account = dict(account)
+                if not acct_match:
+                    # Only include properties that matched.
+                    account["property_summaries"] = matching_props
+                filtered.append(account)
+        all_pages = filtered
+
     return all_pages
 
 


### PR DESCRIPTION
## Summary

Closes #69.

- **Strip redundant fields** from `get_account_summaries` responses: removes `name` from account summaries (just `"accountSummaries/ID"`, redundant with `account`), and removes `name`, `parent`, and `property_type` from property summaries (parent is implicit from the containing account, property_type is rarely needed, name is redundant with `property`).
- **Add optional `query` parameter** (case-insensitive display-name search) so agencies with hundreds of accounts can filter server-side instead of consuming tokens on the full list.

## Motivation

For agencies managing many GA4 accounts, `get_account_summaries` returns a large payload with several fields that are either redundant or rarely useful. This inflates token counts unnecessarily when the LLM processes the response. Stripping these fields and adding a search filter directly addresses the issue.

## Changes

- `analytics_mcp/tools/admin/info.py`: Added `_strip_account_summary` helper and `query` parameter to `get_account_summaries`; updated docstring.

## Test plan

- [ ] Verify `get_account_summaries()` (no args) returns results without `name`, `parent`, or `property_type` fields
- [ ] Verify `get_account_summaries(query="example")` filters by display name correctly
- [ ] Verify accounts matching by property name (not account name) only include the matching properties