### PR TITLE
fix: prevent handle inheritance in subprocess to resolve stdio deadlock

### DIFF
--- a/analytics_mcp/tools/client.py
+++ b/analytics_mcp/tools/client.py
@@ -14,6 +14,13 @@
 
 """Client initialization for the Google Analytics APIs."""
 
+import contextlib
+import subprocess
+import threading
+from importlib import metadata
+from unittest.mock import patch
+
+import google.auth
 from google.analytics import (
     admin_v1beta,
     data_v1beta,
@@ -21,9 +28,6 @@ from google.analytics import (
     data_v1alpha,
 )
 from google.api_core.gapic_v1.client_info import ClientInfo
-from importlib import metadata
-import google.auth
-import threading
 
 
 def _get_package_version_with_fallback():
@@ -52,13 +56,33 @@ _client_lock = threading.Lock()
 _CREDENTIALS = None
 
 
+@contextlib.contextmanager
+def prevent_stdio_inheritance():
+    """Prevents child processes from inheriting the parent's stdio handles.
+
+    Fixes a deadlock on Windows where `google.auth.default()` spawns `gcloud`
+    via subprocess without redirecting stdin, causing it to inherit the
+    ProactorEventLoop's overlapping I/O handles used by MCP's stdio transport.
+    """
+    original_popen = subprocess.Popen
+
+    def safe_popen(*args, **kwargs):
+        if kwargs.get("stdin") is None:
+            kwargs["stdin"] = subprocess.DEVNULL
+        return original_popen(*args, **kwargs)
+
+    with patch("subprocess.Popen", new=safe_popen):
+        yield
+
+
 def _get_credentials():
     global _CREDENTIALS
     # Expected to be called under _client_lock
     if _CREDENTIALS is None:
-        _CREDENTIALS, _ = google.auth.default(
-            scopes=[_READ_ONLY_ANALYTICS_SCOPE]
-        )
+        with prevent_stdio_inheritance():
+            _CREDENTIALS, _ = google.auth.default(
+                scopes=[_READ_ONLY_ANALYTICS_SCOPE]
+            )
     return _CREDENTIALS
 
 


### PR DESCRIPTION
### Description
This PR addresses the remaining Windows deadlock issue over `stdio` transport. 

While PR #151 successfully moved client initialization to a background thread to prevent main-thread blocking, the underlying OS-level collision still persists: on Windows, the `subprocess.Popen` call spawned by `google.auth.default()` defaults to `stdin=None`. This causes the child process (e.g., `gcloud`) to inherit the parent's `stdin` handle. Because the parent's `stdin` is actively bound to the `ProactorEventLoop` (Overlapped I/O) managing the MCP `stdio` transport, this shared reference corrupts the pipe state, resulting in a hard crash (`[WinError 6] The handle is invalid` and `ValueError: I/O operation on closed pipe`).

To resolve this without altering the core initialization architecture or removing `gcloud` feature parity for Windows users, this fix introduces a `prevent_stdio_inheritance` context manager. It temporarily patches `subprocess.Popen` to enforce `stdin=subprocess.DEVNULL` during the `google.auth.default()` call. This isolates the standard file handles, preventing destructive inheritance while allowing `gcloud` to successfully fetch credentials.

### Changes
- Wrapped `google.auth.default()` in `analytics_mcp/tools/client.py` with a `prevent_stdio_inheritance` context manager.
- Ensures 100% feature parity for developers relying on Application Default Credentials via `gcloud`.
- Verified locally on Windows 11 using a `stdio` integration harness. The server no longer hangs on initialization.
- Formatted with `black` and wrapped to the 80-character limit required by `nox`.

Resolves #134