### PR TITLE
WIP: add gemini-extension

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,29 @@
+{
+  "name": "analytics-mcp",
+  "version": "1.0.0",
+  "description": "Google Analytics MCP Server for managing GA properties and accounts.",
+  "mcpServers": {
+    "analytics-mcp": {
+      "command": "pipx",
+      "args": [
+        "run",
+        "analytics-mcp"
+      ],
+      "env": {}
+    }
+  },
+  "settings": [
+    {
+      "name": "Google application credentials path",
+      "description": "Path of your google application credentials",
+      "envVar": "GOOGLE_APPLICATION_CREDENTIALS",
+      "sensitive": true
+    },
+    {
+      "name": "Google project id",
+      "description": "google project id",
+      "envVar": "GOOGLE_PROJECT_ID",
+      "sensitive": true
+    }    
+  ]
+}


### PR DESCRIPTION
Closes https://github.com/googleanalytics/google-analytics-mcp/issues/100

I configured this as a gemini extension on my own machine as

```
{
  "name": "analytics-mcp",
  "version": "1.0.0",
  "description": "Google Analytics MCP Server for managing GA properties and accounts.",
  "mcpServers": {
    "analytics-mcp": {
      "command": "pipx",
      "args": [
        "run",
        "analytics-mcp"
      ],
      "env": {
        "GOOGLE_APPLICATION_CREDENTIALS": "XXXXXXXXXXX",
        "GOOGLE_PROJECT_ID": "XXXXXXXXXXX"
      }
    }
  }
}
```

I tried to look at https://github.com/gemini-cli-extensions/nanobanana to see how to include environmental variable injection when you install the extension.

Not tested but may help if someone on the teams wants to implement