### PR TITLE
Add Google Analytics MCP section for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ Credentials saved to file: [PATH_TO_CREDENTIALS_JSON]
     }
     ```
 
+### Configure Claude Code
+
+1.  Add the MCP server with the following command:
+
+    Replace `PATH_TO_CREDENTIALS_JSON` with the path you copied in the previous
+    step, and replace `YOUR_PROJECT_ID` with the
+    [project ID](https://support.google.com/googleapi/answer/7014113) of your
+    Google Cloud project.
+
+    ```shell
+    claude mcp add analytics-mcp \
+      --scope user \
+      -e "GOOGLE_APPLICATION_CREDENTIALS=PATH_TO_CREDENTIALS_JSON" \
+      -e "GOOGLE_PROJECT_ID=YOUR_PROJECT_ID" \
+      -- pipx run analytics-mcp
+    ```
+
 ## Try it out 🥼
 
 Launch Gemini Code Assist or Gemini CLI and type `/mcp`. You should see


### PR DESCRIPTION
## Summary
Added detailed setup instructions for using this MCP with **Claude Code** (Anthropic's Claude Desktop / CLI). All steps have been tested locally.

### Why
This makes it much easier for users working in the Claude ecosystem to quickly set up and start using the Google Analytics MCP.

### How to Test
1. Follow the new instructions in the README
2. Run `claude mcp list` to verify `analytics-mcp` is registered
3. Type `mcp` in Claude Code / Gemini CLI to confirm the tool appears
