### PR TITLE
Expand the read-only GA4 MCP surface for Codex workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,45 @@ to provide several
 - `run_realtime_report`: Runs a Google Analytics realtime report using the
   Data API.
 
+### Additional read-only tools currently exposed by the server
+
+Admin/account discovery:
+
+- `list_accounts`: Returns accessible Google Analytics accounts.
+- `get_account`: Returns details for one account.
+- `list_properties`: Returns accessible properties, optionally filtered to one account.
+- `list_data_streams`: Returns data streams for a property.
+- `get_data_stream`: Returns one data stream for a property.
+- `get_data_retention_settings`: Returns the data retention settings for a property.
+- `get_data_sharing_settings`: Returns the data sharing settings for an account.
+- `list_firebase_links`: Returns Firebase links for a property.
+- `list_key_events`: Returns key events for a property.
+- `get_key_event`: Returns one key event for a property.
+- `list_conversion_events`: Returns conversion events for a property.
+- `get_conversion_event`: Returns one conversion event for a property.
+- `list_custom_dimensions`: Returns custom dimensions for a property.
+- `get_custom_dimension`: Returns one custom dimension for a property.
+- `list_custom_metrics`: Returns custom metrics for a property.
+- `get_custom_metric`: Returns one custom metric for a property.
+- `run_access_report`: Runs an access report for a property. This can require administrator access.
+- `list_property_annotations`: Returns property annotations via the Admin Alpha API.
+
+Reporting/metadata:
+
+- `get_property_metadata`: Returns the full GA4 metadata catalog for a property.
+- `run_pivot_report`: Runs a GA4 pivot report.
+- `check_report_compatibility`: Checks whether a dimension/metric combination is valid.
+- `run_conversions_report`: Runs a conversions-focused report via the Data Alpha API.
+- `get_property_quotas_snapshot`: Returns the property's current quota snapshot.
+- `list_audience_exports`: Returns audience exports for a property.
+- `get_audience_export`: Returns one audience export for a property.
+- `list_audience_lists`: Returns audience lists for a property.
+- `get_audience_list`: Returns one audience list for a property.
+- `list_recurring_audience_lists`: Returns recurring audience lists for a property.
+- `get_recurring_audience_list`: Returns one recurring audience list for a property.
+- `list_report_tasks`: Returns report tasks for a property.
+- `get_report_task`: Returns one report task for a property.
+
 ## Setup instructions 🔧
 
 ✨ Watch the [Google Analytics MCP Setup
@@ -205,3 +244,48 @@ Here are some sample prompts to get you started:
 ## Contributing ✨
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).
+
+## Codex notes
+
+This server works with Codex over stdio. A project-local launch command that
+works in `B:\\source\\ads` is:
+
+```json
+{
+  "mcpServers": {
+    "analytics-mcp-local": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--project",
+        "B:\\source\\ads\\external\\google-analytics-mcp",
+        "python",
+        "-m",
+        "analytics_mcp.server"
+      ],
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "B:\\source\\ads\\i-meble-eu-api-analityk-59fbaa22ca49.json",
+        "GOOGLE_PROJECT_ID": "i-meble-eu-api-analityk"
+      }
+    }
+  }
+}
+```
+
+For live read-only validation against a property, run:
+
+```powershell
+uv run --project B:\source\ads\external\google-analytics-mcp python scripts\validate_live_read_tools.py --property-id 252198517 --output-json B:\source\ads\outputs\ga4_mcp_validation_2026_06_27\live_validation.json
+```
+
+The validator is read-only. By default it uses the last 7 completed days ending
+yesterday, but you can override that with `--start-date YYYY-MM-DD` and
+`--end-date YYYY-MM-DD`. When you run it outside the Codex MCP server config,
+make sure `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_PROJECT_ID` are set in
+the shell environment first.
+
+For an SDK-vs-MCP read-surface audit, run:
+
+```powershell
+uv run --project B:\source\ads\external\google-analytics-mcp python scripts\audit_read_surface.py --output-json B:\source\ads\outputs\ga4_mcp_validation_2026_06_27\read_surface_audit.json
+```

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -21,7 +21,6 @@ server.
 # MCP Server Imports
 import json
 import sys
-from json import tool
 from mcp import types as mcp_types  # Use alias to avoid conflict
 from mcp.server.lowlevel import Server
 
@@ -34,6 +33,25 @@ from analytics_mcp.tools.admin.info import (
     list_google_ads_links,
     get_property_details,
     list_property_annotations,
+)
+from analytics_mcp.tools.admin.discovery import (
+    list_accounts,
+    get_account,
+    list_properties,
+    list_data_streams,
+    get_data_stream,
+    get_data_retention_settings,
+    get_data_sharing_settings,
+    list_firebase_links,
+    list_key_events,
+    get_key_event,
+    list_conversion_events,
+    get_conversion_event,
+    list_custom_dimensions,
+    get_custom_dimension,
+    list_custom_metrics,
+    get_custom_metric,
+    run_access_report,
 )
 from analytics_mcp.tools.reporting.core import (
     run_report,
@@ -54,6 +72,22 @@ from analytics_mcp.tools.reporting.conversions import (
     run_conversions_report,
     _run_conversions_report_description,
 )
+from analytics_mcp.tools.reporting.advanced import (
+    get_property_metadata,
+    run_pivot_report,
+    check_report_compatibility,
+    get_property_quotas_snapshot,
+)
+from analytics_mcp.tools.reporting.async_reads import (
+    list_audience_exports,
+    get_audience_export,
+    list_audience_lists,
+    get_audience_list,
+    list_recurring_audience_lists,
+    get_recurring_audience_list,
+    list_report_tasks,
+    get_report_task,
+)
 
 run_report_with_description = FunctionTool(run_report)
 run_report_with_description.description = _run_report_description()
@@ -73,14 +107,43 @@ run_conversions_report_with_description.description = (
 # Instantiate the ADK tools
 tools = [
     FunctionTool(get_account_summaries),
+    FunctionTool(list_accounts),
+    FunctionTool(get_account),
     FunctionTool(list_google_ads_links),
     FunctionTool(get_property_details),
+    FunctionTool(list_properties),
+    FunctionTool(list_data_streams),
+    FunctionTool(get_data_stream),
+    FunctionTool(get_data_retention_settings),
+    FunctionTool(get_data_sharing_settings),
+    FunctionTool(list_firebase_links),
+    FunctionTool(list_key_events),
+    FunctionTool(get_key_event),
+    FunctionTool(list_conversion_events),
+    FunctionTool(get_conversion_event),
+    FunctionTool(list_custom_dimensions),
+    FunctionTool(get_custom_dimension),
+    FunctionTool(list_custom_metrics),
+    FunctionTool(get_custom_metric),
+    FunctionTool(run_access_report),
     FunctionTool(list_property_annotations),
     FunctionTool(get_custom_dimensions_and_metrics),
+    FunctionTool(get_property_metadata),
     run_report_with_description,
+    FunctionTool(run_pivot_report),
+    FunctionTool(check_report_compatibility),
     run_realtime_report_with_description,
     run_funnel_report_with_description,
     run_conversions_report_with_description,
+    FunctionTool(get_property_quotas_snapshot),
+    FunctionTool(list_audience_exports),
+    FunctionTool(get_audience_export),
+    FunctionTool(list_audience_lists),
+    FunctionTool(get_audience_list),
+    FunctionTool(list_recurring_audience_lists),
+    FunctionTool(get_recurring_audience_list),
+    FunctionTool(list_report_tasks),
+    FunctionTool(get_report_task),
 ]
 
 tool_map = {t.name: t for t in tools}
@@ -154,11 +217,13 @@ for tool in mcp_tools:
 
 @app.list_tools()
 async def list_tools() -> list[mcp_types.Tool]:
+    """Returns the MCP tool surface exposed by this server."""
     return mcp_tools
 
 
 @app.call_tool()
 async def call_mcp_tool(name: str, arguments: dict) -> list[mcp_types.Content]:
+    """Executes one registered tool and serializes the result to MCP text content."""
     if name in tool_map:
         tool = tool_map[name]
         try:

--- a/analytics_mcp/tools/admin/discovery.py
+++ b/analytics_mcp/tools/admin/discovery.py
@@ -1,0 +1,305 @@
+# Copyright 2026 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Additional read-only admin tools for GA4 MCP."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.client import create_admin_api_client
+from analytics_mcp.tools.utils import (
+    construct_account_rn,
+    construct_conversion_event_rn,
+    construct_custom_dimension_rn,
+    construct_custom_metric_rn,
+    construct_data_retention_settings_rn,
+    construct_data_sharing_settings_rn,
+    construct_data_stream_rn,
+    construct_key_event_rn,
+    construct_property_rn,
+    proto_to_dict,
+)
+from google.analytics import admin_v1beta
+
+
+async def list_accounts() -> List[Dict[str, Any]]:
+    """Returns accessible Google Analytics accounts."""
+
+    def _sync_call():
+        pager = create_admin_api_client().list_accounts(
+            request=admin_v1beta.ListAccountsRequest()
+        )
+        return [proto_to_dict(account) for account in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_account(account_id: int | str) -> Dict[str, Any]:
+    """Returns details for one Google Analytics account."""
+    request = admin_v1beta.GetAccountRequest(
+        name=construct_account_rn(account_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_account(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_properties(
+    account_id: int | str | None = None,
+    show_deleted: bool = False,
+) -> List[Dict[str, Any]]:
+    """Returns accessible properties, optionally filtered to one account."""
+    request = admin_v1beta.ListPropertiesRequest(show_deleted=show_deleted)
+    if account_id is not None:
+        request.filter = f"parent:{construct_account_rn(account_id)}"
+
+    def _sync_call():
+        pager = create_admin_api_client().list_properties(request=request)
+        return [proto_to_dict(prop) for prop in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_data_streams(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns data streams for a property."""
+    request = admin_v1beta.ListDataStreamsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_data_streams(request=request)
+        return [proto_to_dict(stream) for stream in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_data_stream(
+    property_id: int | str,
+    data_stream_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one data stream for a property."""
+    request = admin_v1beta.GetDataStreamRequest(
+        name=construct_data_stream_rn(property_id, data_stream_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_data_stream(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def get_data_retention_settings(property_id: int | str) -> Dict[str, Any]:
+    """Returns data retention settings for a property."""
+    request = admin_v1beta.GetDataRetentionSettingsRequest(
+        name=construct_data_retention_settings_rn(property_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_data_retention_settings(
+            request=request
+        )
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def get_data_sharing_settings(account_id: int | str) -> Dict[str, Any]:
+    """Returns data sharing settings for an account."""
+    request = admin_v1beta.GetDataSharingSettingsRequest(
+        name=construct_data_sharing_settings_rn(account_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_data_sharing_settings(
+            request=request
+        )
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_firebase_links(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns Firebase links for a property."""
+    request = admin_v1beta.ListFirebaseLinksRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_firebase_links(request=request)
+        return [proto_to_dict(link) for link in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_key_events(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns key events for a property."""
+    request = admin_v1beta.ListKeyEventsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_key_events(request=request)
+        return [proto_to_dict(event) for event in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_key_event(
+    property_id: int | str,
+    key_event_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one key event for a property."""
+    request = admin_v1beta.GetKeyEventRequest(
+        name=construct_key_event_rn(property_id, key_event_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_key_event(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_conversion_events(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns conversion events for a property."""
+    request = admin_v1beta.ListConversionEventsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_conversion_events(request=request)
+        return [proto_to_dict(event) for event in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_conversion_event(
+    property_id: int | str,
+    conversion_event_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one conversion event for a property."""
+    request = admin_v1beta.GetConversionEventRequest(
+        name=construct_conversion_event_rn(property_id, conversion_event_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_conversion_event(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_custom_dimensions(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns custom dimensions for a property."""
+    request = admin_v1beta.ListCustomDimensionsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_custom_dimensions(request=request)
+        return [proto_to_dict(dimension) for dimension in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_custom_dimension(
+    property_id: int | str,
+    custom_dimension_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one custom dimension for a property."""
+    request = admin_v1beta.GetCustomDimensionRequest(
+        name=construct_custom_dimension_rn(property_id, custom_dimension_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_custom_dimension(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_custom_metrics(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns custom metrics for a property."""
+    request = admin_v1beta.ListCustomMetricsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_admin_api_client().list_custom_metrics(request=request)
+        return [proto_to_dict(metric) for metric in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_custom_metric(
+    property_id: int | str,
+    custom_metric_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one custom metric for a property."""
+    request = admin_v1beta.GetCustomMetricRequest(
+        name=construct_custom_metric_rn(property_id, custom_metric_id)
+    )
+
+    def _sync_call():
+        return create_admin_api_client().get_custom_metric(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def run_access_report(
+    property_id: int | str,
+    dimensions: List[Dict[str, Any]],
+    metrics: List[Dict[str, Any]],
+    date_ranges: List[Dict[str, Any]],
+    dimension_filter: Dict[str, Any] = None,
+    metric_filter: Dict[str, Any] = None,
+    limit: int = None,
+    offset: int = None,
+    time_zone: str = None,
+) -> Dict[str, Any]:
+    """Runs an Analytics Admin access report for a property.
+
+    This report often requires administrator-level access on the property.
+    """
+    request = admin_v1beta.RunAccessReportRequest(
+        entity=construct_property_rn(property_id),
+        dimensions=[
+            admin_v1beta.AccessDimension(dimension) for dimension in dimensions
+        ],
+        metrics=[admin_v1beta.AccessMetric(metric) for metric in metrics],
+        date_ranges=[
+            admin_v1beta.AccessDateRange(date_range)
+            for date_range in date_ranges
+        ],
+    )
+    if dimension_filter:
+        request.dimension_filter = admin_v1beta.AccessFilterExpression(
+            dimension_filter
+        )
+    if metric_filter:
+        request.metric_filter = admin_v1beta.AccessFilterExpression(metric_filter)
+    if limit:
+        request.limit = limit
+    if offset:
+        request.offset = offset
+    if time_zone:
+        request.time_zone = time_zone
+
+    def _sync_call():
+        return create_admin_api_client().run_access_report(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))

--- a/analytics_mcp/tools/reporting/advanced.py
+++ b/analytics_mcp/tools/reporting/advanced.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Additional read-only reporting and metadata tools for GA4 MCP."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.client import (
+    create_data_api_alpha_client,
+    create_data_api_client,
+)
+from analytics_mcp.tools.utils import (
+    construct_property_quotas_snapshot_rn,
+    construct_property_rn,
+    proto_to_dict,
+)
+from google.analytics import data_v1alpha, data_v1beta
+
+
+async def get_property_metadata(property_id: int | str) -> Dict[str, Any]:
+    """Returns full property metadata, including all dimensions and metrics."""
+
+    def _sync_call():
+        return create_data_api_client().get_metadata(
+            request=data_v1beta.GetMetadataRequest(
+                name=f"{construct_property_rn(property_id)}/metadata"
+            )
+        )
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def run_pivot_report(
+    property_id: int | str,
+    date_ranges: List[Dict[str, Any]],
+    dimensions: List[str],
+    metrics: List[str],
+    pivots: List[Dict[str, Any]],
+    dimension_filter: Dict[str, Any] = None,
+    metric_filter: Dict[str, Any] = None,
+    currency_code: str = None,
+    keep_empty_rows: bool = False,
+    return_property_quota: bool = False,
+) -> Dict[str, Any]:
+    """Runs a Google Analytics Data API pivot report."""
+    request = data_v1beta.RunPivotReportRequest(
+        property=construct_property_rn(property_id),
+        dimensions=[data_v1beta.Dimension(name=dimension) for dimension in dimensions],
+        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+        date_ranges=[data_v1beta.DateRange(dr) for dr in date_ranges],
+        pivots=[data_v1beta.Pivot(pivot) for pivot in pivots],
+        keep_empty_rows=keep_empty_rows,
+        return_property_quota=return_property_quota,
+    )
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
+        )
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+    if currency_code:
+        request.currency_code = currency_code
+
+    def _sync_call():
+        return create_data_api_client().run_pivot_report(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def check_report_compatibility(
+    property_id: int | str,
+    dimensions: List[str],
+    metrics: List[str],
+    dimension_filter: Dict[str, Any] = None,
+    metric_filter: Dict[str, Any] = None,
+    compatibility_filter: str = None,
+) -> Dict[str, Any]:
+    """Checks whether dimensions and metrics are compatible in one report."""
+    request = data_v1beta.CheckCompatibilityRequest(
+        property=construct_property_rn(property_id),
+        dimensions=[data_v1beta.Dimension(name=dimension) for dimension in dimensions],
+        metrics=[data_v1beta.Metric(name=metric) for metric in metrics],
+    )
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
+        )
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+    if compatibility_filter:
+        request.compatibility_filter = compatibility_filter
+
+    def _sync_call():
+        return create_data_api_client().check_compatibility(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def get_property_quotas_snapshot(
+    property_id: int | str,
+) -> Dict[str, Any]:
+    """Returns the property's quota snapshot from the Alpha Data API."""
+    request = data_v1alpha.GetPropertyQuotasSnapshotRequest(
+        name=construct_property_quotas_snapshot_rn(property_id)
+    )
+
+    def _sync_call():
+        return create_data_api_alpha_client().get_property_quotas_snapshot(
+            request=request
+        )
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))

--- a/analytics_mcp/tools/reporting/async_reads.py
+++ b/analytics_mcp/tools/reporting/async_reads.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Additional asynchronous read-only reporting tools for GA4 MCP."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.client import (
+    create_data_api_alpha_client,
+    create_data_api_client,
+)
+from analytics_mcp.tools.utils import (
+    construct_audience_export_rn,
+    construct_audience_list_rn,
+    construct_property_rn,
+    construct_recurring_audience_list_rn,
+    construct_report_task_rn,
+    proto_to_dict,
+)
+from google.analytics import data_v1alpha, data_v1beta
+
+
+async def list_audience_exports(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns audience exports for a property."""
+    request = data_v1beta.ListAudienceExportsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_data_api_client().list_audience_exports(request=request)
+        return [proto_to_dict(audience_export) for audience_export in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_audience_export(
+    property_id: int | str,
+    audience_export_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one audience export for a property."""
+    request = data_v1beta.GetAudienceExportRequest(
+        name=construct_audience_export_rn(property_id, audience_export_id)
+    )
+
+    def _sync_call():
+        return create_data_api_client().get_audience_export(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_audience_lists(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns audience lists for a property."""
+    request = data_v1alpha.ListAudienceListsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_data_api_alpha_client().list_audience_lists(
+            request=request
+        )
+        return [proto_to_dict(audience_list) for audience_list in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_audience_list(
+    property_id: int | str,
+    audience_list_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one audience list for a property."""
+    request = data_v1alpha.GetAudienceListRequest(
+        name=construct_audience_list_rn(property_id, audience_list_id)
+    )
+
+    def _sync_call():
+        return create_data_api_alpha_client().get_audience_list(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_recurring_audience_lists(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns recurring audience lists for a property."""
+    request = data_v1alpha.ListRecurringAudienceListsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_data_api_alpha_client().list_recurring_audience_lists(
+            request=request
+        )
+        return [
+            proto_to_dict(recurring_audience_list)
+            for recurring_audience_list in pager
+        ]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_recurring_audience_list(
+    property_id: int | str,
+    recurring_audience_list_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one recurring audience list for a property."""
+    request = data_v1alpha.GetRecurringAudienceListRequest(
+        name=construct_recurring_audience_list_rn(
+            property_id, recurring_audience_list_id
+        )
+    )
+
+    def _sync_call():
+        return create_data_api_alpha_client().get_recurring_audience_list(
+            request=request
+        )
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))
+
+
+async def list_report_tasks(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns report tasks for a property."""
+    request = data_v1alpha.ListReportTasksRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        pager = create_data_api_alpha_client().list_report_tasks(request=request)
+        return [proto_to_dict(report_task) for report_task in pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_report_task(
+    property_id: int | str,
+    report_task_id: int | str,
+) -> Dict[str, Any]:
+    """Returns one report task for a property."""
+    request = data_v1alpha.GetReportTaskRequest(
+        name=construct_report_task_rn(property_id, report_task_id)
+    )
+
+    def _sync_call():
+        return create_data_api_alpha_client().get_report_task(request=request)
+
+    return proto_to_dict(await asyncio.to_thread(_sync_call))

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -19,29 +19,224 @@ from typing import Any, Dict
 import proto
 
 
-def construct_property_rn(property_value: int | str) -> str:
-    """Returns a property resource name in the format required by APIs."""
-    property_num = None
-    if isinstance(property_value, int):
-        property_num = property_value
-    elif isinstance(property_value, str):
-        property_value = property_value.strip()
-        if property_value.isdigit():
-            property_num = int(property_value)
-        elif property_value.startswith("properties/"):
-            numeric_part = property_value.split("/")[-1]
+def _construct_numeric_resource_name(
+    value: int | str,
+    prefix: str,
+    description: str,
+) -> str:
+    """Returns a normalized resource name for numeric GA resources."""
+    resource_num = None
+    if isinstance(value, int):
+        resource_num = value
+    elif isinstance(value, str):
+        value = value.strip()
+        if value.isdigit():
+            resource_num = int(value)
+        elif value.startswith(f"{prefix}/"):
+            numeric_part = value.split("/")[-1]
             if numeric_part.isdigit():
-                property_num = int(numeric_part)
-    if property_num is None:
+                resource_num = int(numeric_part)
+    if resource_num is None:
         raise ValueError(
             (
-                f"Invalid property ID: {property_value}. "
-                "A valid property value is either a number or a string starting "
-                "with 'properties/' and followed by a number."
+                f"Invalid {description}: {value}. "
+                f"A valid value is either a number or a string starting with "
+                f"'{prefix}/' and followed by a number."
             )
         )
+    return f"{prefix}/{resource_num}"
 
-    return f"properties/{property_num}"
+
+def construct_property_rn(property_value: int | str) -> str:
+    """Returns a property resource name in the format required by APIs."""
+    return _construct_numeric_resource_name(
+        property_value, "properties", "property ID"
+    )
+
+
+def construct_account_rn(account_value: int | str) -> str:
+    """Returns an account resource name in the format required by APIs."""
+    return _construct_numeric_resource_name(
+        account_value, "accounts", "account ID"
+    )
+
+
+def construct_data_stream_rn(
+    property_value: int | str, data_stream_value: int | str
+) -> str:
+    """Returns a data stream resource name."""
+    property_rn = construct_property_rn(property_value)
+    if isinstance(data_stream_value, int):
+        return f"{property_rn}/dataStreams/{data_stream_value}"
+    if isinstance(data_stream_value, str):
+        data_stream_value = data_stream_value.strip()
+        if data_stream_value.startswith(f"{property_rn}/dataStreams/"):
+            return data_stream_value
+        if data_stream_value.startswith("properties/") and "/dataStreams/" in data_stream_value:
+            return data_stream_value
+        if data_stream_value.isdigit():
+            return f"{property_rn}/dataStreams/{data_stream_value}"
+    raise ValueError(
+        (
+            f"Invalid data stream ID: {data_stream_value}. "
+            "A valid value is either a number or a full data stream resource name."
+        )
+    )
+
+
+def construct_property_child_rn(
+    property_value: int | str,
+    collection: str,
+    child_value: int | str,
+    description: str,
+    *,
+    allow_non_numeric: bool = False,
+) -> str:
+    """Returns a resource name for one property-scoped child resource."""
+    property_rn = construct_property_rn(property_value)
+    collection_prefix = f"{property_rn}/{collection}/"
+    if isinstance(child_value, int):
+        return f"{collection_prefix}{child_value}"
+    if isinstance(child_value, str):
+        child_value = child_value.strip()
+        if child_value.startswith(collection_prefix):
+            return child_value
+        if child_value.startswith("properties/") and f"/{collection}/" in child_value:
+            return child_value
+        if child_value.isdigit() or (allow_non_numeric and child_value):
+            return f"{collection_prefix}{child_value}"
+    raise ValueError(
+        (
+            f"Invalid {description}: {child_value}. "
+            "A valid value is either a resource ID or a full resource name."
+        )
+    )
+
+
+def construct_key_event_rn(
+    property_value: int | str, key_event_value: int | str
+) -> str:
+    """Returns a key event resource name."""
+    property_rn = construct_property_rn(property_value)
+    if isinstance(key_event_value, int):
+        return f"{property_rn}/keyEvents/{key_event_value}"
+    if isinstance(key_event_value, str):
+        key_event_value = key_event_value.strip()
+        if key_event_value.startswith(f"{property_rn}/keyEvents/"):
+            return key_event_value
+        if key_event_value.startswith("properties/") and "/keyEvents/" in key_event_value:
+            return key_event_value
+        if key_event_value:
+            return f"{property_rn}/keyEvents/{key_event_value}"
+    raise ValueError(
+        (
+            f"Invalid key event ID: {key_event_value}. "
+            "A valid value is a non-empty ID or a full key event resource name."
+        )
+    )
+
+
+def construct_conversion_event_rn(
+    property_value: int | str, conversion_event_value: int | str
+) -> str:
+    """Returns a conversion event resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "conversionEvents",
+        conversion_event_value,
+        "conversion event ID",
+    )
+
+
+def construct_custom_dimension_rn(
+    property_value: int | str, custom_dimension_value: int | str
+) -> str:
+    """Returns a custom dimension resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "customDimensions",
+        custom_dimension_value,
+        "custom dimension ID",
+    )
+
+
+def construct_custom_metric_rn(
+    property_value: int | str, custom_metric_value: int | str
+) -> str:
+    """Returns a custom metric resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "customMetrics",
+        custom_metric_value,
+        "custom metric ID",
+    )
+
+
+def construct_audience_export_rn(
+    property_value: int | str, audience_export_value: int | str
+) -> str:
+    """Returns an audience export resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "audienceExports",
+        audience_export_value,
+        "audience export ID",
+        allow_non_numeric=True,
+    )
+
+
+def construct_audience_list_rn(
+    property_value: int | str, audience_list_value: int | str
+) -> str:
+    """Returns an audience list resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "audienceLists",
+        audience_list_value,
+        "audience list ID",
+        allow_non_numeric=True,
+    )
+
+
+def construct_recurring_audience_list_rn(
+    property_value: int | str, recurring_audience_list_value: int | str
+) -> str:
+    """Returns a recurring audience list resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "recurringAudienceLists",
+        recurring_audience_list_value,
+        "recurring audience list ID",
+        allow_non_numeric=True,
+    )
+
+
+def construct_report_task_rn(
+    property_value: int | str, report_task_value: int | str
+) -> str:
+    """Returns a report task resource name."""
+    return construct_property_child_rn(
+        property_value,
+        "reportTasks",
+        report_task_value,
+        "report task ID",
+        allow_non_numeric=True,
+    )
+
+
+def construct_data_retention_settings_rn(property_value: int | str) -> str:
+    """Returns a data retention settings resource name."""
+    return f"{construct_property_rn(property_value)}/dataRetentionSettings"
+
+
+def construct_data_sharing_settings_rn(account_value: int | str) -> str:
+    """Returns a data sharing settings resource name."""
+    return f"{construct_account_rn(account_value)}/dataSharingSettings"
+
+
+def construct_property_quotas_snapshot_rn(property_value: int | str) -> str:
+    """Returns a property quota snapshot resource name."""
+    return f"{construct_property_rn(property_value)}/propertyQuotasSnapshot"
 
 
 def proto_to_dict(obj: proto.Message) -> Dict[str, Any]:

--- a/scripts/audit_read_surface.py
+++ b/scripts/audit_read_surface.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+"""Audits SDK read methods against the exposed MCP tool surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import analytics_mcp.coordinator as coordinator
+from google.analytics import admin_v1beta, data_v1alpha, data_v1beta
+
+
+READ_PREFIXES = ("get_", "list_", "run_", "check_")
+IGNORED_TRANSPORT_METHODS = {
+    "get_mtls_endpoint_and_cert_source",
+    "get_transport_class",
+}
+INTENTIONALLY_OMITTED = {
+    "get_measurement_protocol_secret": "secret_material",
+    "list_measurement_protocol_secrets": "secret_material",
+    "get_property": "covered_by_get_property_details",
+    "get_metadata": "covered_by_get_property_metadata",
+}
+SDK_TO_MCP_NAME_ALIASES = {
+    "list_account_summaries": "get_account_summaries",
+    "check_compatibility": "check_report_compatibility",
+}
+
+
+def _sdk_read_methods() -> dict[str, list[str]]:
+    classes = {
+        "admin_v1beta.AnalyticsAdminServiceClient": (
+            admin_v1beta.AnalyticsAdminServiceClient
+        ),
+        "data_v1beta.BetaAnalyticsDataClient": data_v1beta.BetaAnalyticsDataClient,
+        "data_v1alpha.AlphaAnalyticsDataClient": (
+            data_v1alpha.AlphaAnalyticsDataClient
+        ),
+    }
+    inventory: dict[str, list[str]] = {}
+    for label, cls in classes.items():
+        methods = []
+        for name in sorted(dir(cls)):
+            if name.startswith(READ_PREFIXES) and name not in IGNORED_TRANSPORT_METHODS:
+                attr = getattr(cls, name)
+                if callable(attr):
+                    methods.append(name)
+        inventory[label] = methods
+    return inventory
+
+
+def build_audit() -> dict:
+    sdk_inventory = _sdk_read_methods()
+    sdk_method_set = {
+        method for methods in sdk_inventory.values() for method in methods
+    }
+    exposed_tools = sorted(tool.name for tool in coordinator.mcp_tools)
+    exposed_tool_set = set(exposed_tools)
+    covered_sdk_methods = {
+        method
+        for method in sdk_method_set
+        if method in exposed_tool_set
+        or SDK_TO_MCP_NAME_ALIASES.get(method) in exposed_tool_set
+    }
+
+    missing_from_mcp = sorted(
+        method
+        for method in sdk_method_set
+        if method not in covered_sdk_methods
+        and method not in INTENTIONALLY_OMITTED
+    )
+    intentionally_omitted = {
+        method: INTENTIONALLY_OMITTED[method]
+        for method in sorted(INTENTIONALLY_OMITTED)
+        if method in sdk_method_set
+    }
+
+    return {
+        "sdk_read_methods_by_client": sdk_inventory,
+        "exposed_mcp_tools": exposed_tools,
+        "intentionally_omitted": intentionally_omitted,
+        "sdk_to_mcp_name_aliases": SDK_TO_MCP_NAME_ALIASES,
+        "missing_from_mcp": missing_from_mcp,
+        "summary": {
+            "sdk_read_method_count": len(sdk_method_set),
+            "exposed_tool_count": len(exposed_tools),
+            "intentionally_omitted_count": len(intentionally_omitted),
+            "unexplained_missing_count": len(missing_from_mcp),
+        },
+    }
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-json", required=True)
+    args = parser.parse_args()
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = build_audit()
+    output_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_live_read_tools.py
+++ b/scripts/validate_live_read_tools.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+
+"""Live validation for the read-only Google Analytics MCP tool surface.
+
+This script is intentionally scoped to read-only tools. It does not create,
+update, delete, or mutate Google Analytics resources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import date, timedelta
+import json
+from pathlib import Path
+from typing import Any
+
+from analytics_mcp.tools.admin.info import (
+    get_account_summaries,
+    get_property_details,
+    list_google_ads_links,
+    list_property_annotations,
+)
+from analytics_mcp.tools.admin.discovery import (
+    get_account,
+    get_conversion_event,
+    get_custom_dimension,
+    get_custom_metric,
+    get_data_retention_settings,
+    get_data_sharing_settings,
+    get_data_stream,
+    get_key_event,
+    list_accounts,
+    list_conversion_events,
+    list_custom_dimensions,
+    list_custom_metrics,
+    list_data_streams,
+    list_firebase_links,
+    list_key_events,
+    list_properties,
+    run_access_report,
+)
+from analytics_mcp.tools.reporting.advanced import (
+    check_report_compatibility,
+    get_property_metadata,
+    get_property_quotas_snapshot,
+    run_pivot_report,
+)
+from analytics_mcp.tools.reporting.async_reads import (
+    get_audience_export,
+    get_audience_list,
+    get_recurring_audience_list,
+    get_report_task,
+    list_audience_exports,
+    list_audience_lists,
+    list_recurring_audience_lists,
+    list_report_tasks,
+)
+from analytics_mcp.tools.reporting.conversions import run_conversions_report
+from analytics_mcp.tools.reporting.core import run_report
+from analytics_mcp.tools.reporting.funnel import run_funnel_report
+from analytics_mcp.tools.reporting.metadata import get_custom_dimensions_and_metrics
+from analytics_mcp.tools.reporting.realtime import run_realtime_report
+from google.api_core.exceptions import PermissionDenied
+
+
+def _summary(name: str, payload: Any) -> dict[str, Any]:
+    if name in {
+        "get_account_summaries",
+        "list_accounts",
+        "list_google_ads_links",
+        "list_properties",
+        "list_data_streams",
+        "list_property_annotations",
+        "list_firebase_links",
+        "list_key_events",
+        "list_conversion_events",
+        "list_custom_dimensions",
+        "list_custom_metrics",
+        "list_audience_exports",
+        "list_audience_lists",
+        "list_recurring_audience_lists",
+        "list_report_tasks",
+    }:
+        return {"count": len(payload)}
+    if name == "get_property_details":
+        return {
+            "name": payload.get("name"),
+            "display_name": payload.get("display_name"),
+            "currency_code": payload.get("currency_code"),
+            "time_zone": payload.get("time_zone"),
+        }
+    if name == "get_custom_dimensions_and_metrics":
+        return {
+            "custom_dimensions": len(payload.get("custom_dimensions", [])),
+            "custom_metrics": len(payload.get("custom_metrics", [])),
+        }
+    return {
+        "keys": list(payload.keys())[:10],
+        "row_count": payload.get("row_count"),
+        "kind": type(payload).__name__,
+    }
+
+
+def _default_date_window() -> tuple[str, str]:
+    """Returns a small recent window suitable for live validation."""
+    end_date = date.today() - timedelta(days=1)
+    start_date = end_date - timedelta(days=6)
+    return start_date.isoformat(), end_date.isoformat()
+
+
+async def validate(
+    property_id: int | str,
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    results: dict[str, Any] = {}
+    raw_payloads: dict[str, Any] = {}
+
+    async def capture(name: str, coro, *, allow_permission_denied: bool = False):
+        try:
+            value = await coro
+            raw_payloads[name] = value
+            results[name] = {"ok": True, "summary": _summary(name, value)}
+        except PermissionDenied as exc:
+            if allow_permission_denied:
+                results[name] = {
+                    "ok": True,
+                    "access_status": "permission_denied",
+                    "summary": {"error": str(exc)},
+                }
+            else:
+                results[name] = {
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+        except Exception as exc:  # pragma: no cover - integration behavior
+            results[name] = {
+                "ok": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+    def mark_no_resource(name: str, source_list_name: str) -> None:
+        results[name] = {
+            "ok": True,
+            "access_status": "no_resource",
+            "summary": {
+                "reason": f"{source_list_name} returned 0 rows",
+            },
+        }
+
+    await capture("get_account_summaries", get_account_summaries())
+    await capture("list_accounts", list_accounts())
+    await capture("get_property_details", get_property_details(property_id))
+    property_details = raw_payloads.get("get_property_details", {})
+    property_parent = property_details.get("parent") or property_details.get(
+        "account"
+    )
+    account_id = None
+    if isinstance(property_parent, str) and property_parent.startswith(
+        "accounts/"
+    ):
+        account_id = property_parent.split("/")[-1]
+    await capture("list_google_ads_links", list_google_ads_links(property_id))
+    await capture(
+        "list_property_annotations", list_property_annotations(property_id)
+    )
+    await capture(
+        "get_custom_dimensions_and_metrics",
+        get_custom_dimensions_and_metrics(property_id),
+    )
+    if account_id is None:
+        accounts = raw_payloads.get("list_accounts", [])
+        if accounts:
+            first_account_name = accounts[0].get("name")
+            if isinstance(first_account_name, str) and first_account_name.startswith(
+                "accounts/"
+            ):
+                account_id = first_account_name.split("/")[-1]
+    if account_id is not None:
+        await capture("list_properties", list_properties(account_id=account_id))
+        await capture(
+            "get_data_sharing_settings",
+            get_data_sharing_settings(account_id),
+        )
+    else:
+        results["list_properties"] = {
+            "ok": False,
+            "error": "Could not derive an accessible account ID for validation.",
+        }
+        results["get_data_sharing_settings"] = {
+            "ok": False,
+            "error": "Could not derive an accessible account ID for validation.",
+        }
+    await capture("list_data_streams", list_data_streams(property_id))
+    await capture(
+        "get_data_retention_settings",
+        get_data_retention_settings(property_id),
+    )
+    await capture("list_firebase_links", list_firebase_links(property_id))
+    await capture("list_key_events", list_key_events(property_id))
+    await capture("list_conversion_events", list_conversion_events(property_id))
+    await capture("list_custom_dimensions", list_custom_dimensions(property_id))
+    await capture("list_custom_metrics", list_custom_metrics(property_id))
+    await capture("get_property_metadata", get_property_metadata(property_id))
+    accounts = raw_payloads.get("list_accounts", [])
+    if accounts:
+        await capture("get_account", get_account(accounts[0]["name"]))
+    else:
+        mark_no_resource("get_account", "list_accounts")
+    data_streams = raw_payloads.get("list_data_streams", [])
+    if data_streams:
+        await capture(
+            "get_data_stream",
+            get_data_stream(property_id, data_streams[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_data_stream", "list_data_streams")
+    key_events = raw_payloads.get("list_key_events", [])
+    if key_events:
+        await capture(
+            "get_key_event",
+            get_key_event(property_id, key_events[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_key_event", "list_key_events")
+    conversion_events = raw_payloads.get("list_conversion_events", [])
+    if conversion_events:
+        await capture(
+            "get_conversion_event",
+            get_conversion_event(property_id, conversion_events[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_conversion_event", "list_conversion_events")
+    custom_dimensions = raw_payloads.get("list_custom_dimensions", [])
+    if custom_dimensions:
+        await capture(
+            "get_custom_dimension",
+            get_custom_dimension(property_id, custom_dimensions[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_custom_dimension", "list_custom_dimensions")
+    custom_metrics = raw_payloads.get("list_custom_metrics", [])
+    if custom_metrics:
+        await capture(
+            "get_custom_metric",
+            get_custom_metric(property_id, custom_metrics[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_custom_metric", "list_custom_metrics")
+    await capture(
+        "run_report",
+        run_report(
+            property_id=property_id,
+            date_ranges=[{"start_date": start_date, "end_date": end_date}],
+            dimensions=["date", "sessionDefaultChannelGroup"],
+            metrics=["sessions", "totalUsers"],
+            limit=20,
+            return_property_quota=True,
+        ),
+    )
+    await capture(
+        "run_pivot_report",
+        run_pivot_report(
+            property_id=property_id,
+            date_ranges=[{"start_date": start_date, "end_date": end_date}],
+            dimensions=["sessionDefaultChannelGroup"],
+            metrics=["sessions"],
+            pivots=[
+                {
+                    "field_names": ["sessionDefaultChannelGroup"],
+                    "limit": 5,
+                }
+            ],
+            return_property_quota=True,
+        ),
+    )
+    await capture(
+        "check_report_compatibility",
+        check_report_compatibility(
+            property_id=property_id,
+            dimensions=["sessionDefaultChannelGroup"],
+            metrics=["sessions"],
+        ),
+    )
+    await capture(
+        "run_realtime_report",
+        run_realtime_report(
+            property_id=property_id,
+            dimensions=["deviceCategory"],
+            metrics=["activeUsers"],
+            limit=10,
+            return_property_quota=True,
+        ),
+    )
+    await capture(
+        "run_funnel_report",
+        run_funnel_report(
+            property_id=property_id,
+            funnel_steps=[
+                {"name": "Page view", "event": "page_view"},
+                {"name": "Add to cart", "event": "add_to_cart"},
+                {"name": "Purchase", "event": "purchase"},
+            ],
+            date_ranges=[{"start_date": start_date, "end_date": end_date}],
+            return_property_quota=True,
+        ),
+    )
+    await capture(
+        "run_access_report",
+        run_access_report(
+            property_id=property_id,
+            dimensions=[{"dimension_name": "country"}],
+            metrics=[{"metric_name": "accessCount"}],
+            date_ranges=[{"start_date": start_date, "end_date": end_date}],
+            limit=5,
+        ),
+        allow_permission_denied=True,
+    )
+    await capture(
+        "get_property_quotas_snapshot",
+        get_property_quotas_snapshot(property_id),
+    )
+    await capture(
+        "run_conversions_report",
+        run_conversions_report(
+            property_id=property_id,
+            date_ranges=[{"start_date": start_date, "end_date": end_date}],
+            dimensions=["sourceMedium"],
+            metrics=[
+                "allConversionsByConversionDate",
+                "totalRevenueByConversionDate",
+            ],
+            conversion_spec={
+                "conversion_actions": [],
+                "attribution_model": "LAST_CLICK",
+            },
+            limit=10,
+            return_property_quota=True,
+        ),
+    )
+    await capture("list_audience_exports", list_audience_exports(property_id))
+    audience_exports = raw_payloads.get("list_audience_exports", [])
+    if audience_exports:
+        await capture(
+            "get_audience_export",
+            get_audience_export(property_id, audience_exports[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_audience_export", "list_audience_exports")
+    await capture("list_audience_lists", list_audience_lists(property_id))
+    audience_lists = raw_payloads.get("list_audience_lists", [])
+    if audience_lists:
+        await capture(
+            "get_audience_list",
+            get_audience_list(property_id, audience_lists[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_audience_list", "list_audience_lists")
+    await capture(
+        "list_recurring_audience_lists",
+        list_recurring_audience_lists(property_id),
+    )
+    recurring_audience_lists = raw_payloads.get(
+        "list_recurring_audience_lists", []
+    )
+    if recurring_audience_lists:
+        await capture(
+            "get_recurring_audience_list",
+            get_recurring_audience_list(
+                property_id, recurring_audience_lists[0]["name"]
+            ),
+        )
+    else:
+        mark_no_resource(
+            "get_recurring_audience_list",
+            "list_recurring_audience_lists",
+        )
+    await capture("list_report_tasks", list_report_tasks(property_id))
+    report_tasks = raw_payloads.get("list_report_tasks", [])
+    if report_tasks:
+        await capture(
+            "get_report_task",
+            get_report_task(property_id, report_tasks[0]["name"]),
+        )
+    else:
+        mark_no_resource("get_report_task", "list_report_tasks")
+
+    return results
+
+
+def main() -> None:
+    default_start_date, default_end_date = _default_date_window()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--property-id", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--start-date", default=default_start_date)
+    parser.add_argument("--end-date", default=default_end_date)
+    args = parser.parse_args()
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    results = asyncio.run(
+        validate(
+            property_id=args.property_id,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+    )
+    output_path.write_text(
+        json.dumps(results, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/coordinator_test.py
+++ b/tests/coordinator_test.py
@@ -1,0 +1,92 @@
+import unittest
+
+import analytics_mcp.coordinator as coordinator
+
+
+class CoordinatorSchemaTest(unittest.TestCase):
+    def test_expected_tool_names_are_exposed(self):
+        names = [tool.name for tool in coordinator.mcp_tools]
+        self.assertEqual(
+            names,
+            [
+                "get_account_summaries",
+                "list_accounts",
+                "get_account",
+                "list_google_ads_links",
+                "get_property_details",
+                "list_properties",
+                "list_data_streams",
+                "get_data_stream",
+                "get_data_retention_settings",
+                "get_data_sharing_settings",
+                "list_firebase_links",
+                "list_key_events",
+                "get_key_event",
+                "list_conversion_events",
+                "get_conversion_event",
+                "list_custom_dimensions",
+                "get_custom_dimension",
+                "list_custom_metrics",
+                "get_custom_metric",
+                "run_access_report",
+                "list_property_annotations",
+                "get_custom_dimensions_and_metrics",
+                "get_property_metadata",
+                "run_report",
+                "run_pivot_report",
+                "check_report_compatibility",
+                "run_realtime_report",
+                "run_funnel_report",
+                "run_conversions_report",
+                "get_property_quotas_snapshot",
+                "list_audience_exports",
+                "get_audience_export",
+                "list_audience_lists",
+                "get_audience_list",
+                "list_recurring_audience_lists",
+                "get_recurring_audience_list",
+                "list_report_tasks",
+                "get_report_task",
+            ],
+        )
+
+    def test_empty_input_schema_is_normalized(self):
+        tool = next(
+            tool
+            for tool in coordinator.mcp_tools
+            if tool.name == "get_account_summaries"
+        )
+        self.assertEqual(tool.inputSchema, {"type": "object", "properties": {}})
+
+    def test_reporting_tools_have_required_fields(self):
+        required_fields = {
+            "run_report": ["property_id", "date_ranges", "dimensions", "metrics"],
+            "run_realtime_report": ["property_id", "dimensions", "metrics"],
+            "run_conversions_report": [
+                "property_id",
+                "date_ranges",
+                "dimensions",
+                "metrics",
+                "conversion_spec",
+            ],
+        }
+        for tool in coordinator.mcp_tools:
+            if tool.name in required_fields:
+                self.assertEqual(
+                    tool.inputSchema.get("required"),
+                    required_fields[tool.name],
+                )
+
+    def test_input_schema_uses_boolean_additional_properties(self):
+        for tool in coordinator.mcp_tools:
+            self._assert_boolean_additional_properties(tool.inputSchema)
+
+    def _assert_boolean_additional_properties(self, node):
+        if isinstance(node, dict):
+            if "additionalProperties" in node:
+                self.assertIsInstance(node["additionalProperties"], bool)
+            for value in node.values():
+                self._assert_boolean_additional_properties(value)
+        elif isinstance(node, list):
+            for value in node:
+                self._assert_boolean_additional_properties(value)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -44,6 +44,66 @@ class TestUtils(unittest.TestCase):
             "properties/12345",
             "Full resource name should be considered valid",
         )
+        self.assertEqual(
+            utils.construct_account_rn("accounts/32636632"),
+            "accounts/32636632",
+        )
+        self.assertEqual(
+            utils.construct_account_rn("32636632"),
+            "accounts/32636632",
+        )
+        self.assertEqual(
+            utils.construct_data_stream_rn(252198517, "4268733166"),
+            "properties/252198517/dataStreams/4268733166",
+        )
+        self.assertEqual(
+            utils.construct_key_event_rn(252198517, "purchase"),
+            "properties/252198517/keyEvents/purchase",
+        )
+        self.assertEqual(
+            utils.construct_data_retention_settings_rn(252198517),
+            "properties/252198517/dataRetentionSettings",
+        )
+        self.assertEqual(
+            utils.construct_conversion_event_rn(252198517, "2564717350"),
+            "properties/252198517/conversionEvents/2564717350",
+        )
+        self.assertEqual(
+            utils.construct_custom_dimension_rn(252198517, "5688242159"),
+            "properties/252198517/customDimensions/5688242159",
+        )
+        self.assertEqual(
+            utils.construct_custom_metric_rn(252198517, "987654321"),
+            "properties/252198517/customMetrics/987654321",
+        )
+        self.assertEqual(
+            utils.construct_data_sharing_settings_rn(32636632),
+            "accounts/32636632/dataSharingSettings",
+        )
+        self.assertEqual(
+            utils.construct_property_quotas_snapshot_rn(252198517),
+            "properties/252198517/propertyQuotasSnapshot",
+        )
+        self.assertEqual(
+            utils.construct_audience_export_rn(
+                252198517, "properties/252198517/audienceExports/test-export"
+            ),
+            "properties/252198517/audienceExports/test-export",
+        )
+        self.assertEqual(
+            utils.construct_audience_list_rn(252198517, "test-list"),
+            "properties/252198517/audienceLists/test-list",
+        )
+        self.assertEqual(
+            utils.construct_recurring_audience_list_rn(
+                252198517, "test-recurring"
+            ),
+            "properties/252198517/recurringAudienceLists/test-recurring",
+        )
+        self.assertEqual(
+            utils.construct_report_task_rn(252198517, "test-task"),
+            "properties/252198517/reportTasks/test-task",
+        )
 
     def test_construct_property_rn_invalid_input(self):
         """Tests that construct_property_rn raises a ValueError for invalid input."""
@@ -68,3 +128,17 @@ class TestUtils(unittest.TestCase):
             msg="Resource name with more than 2 components should fail",
         ):
             utils.construct_property_rn("properties/123/abc")
+        with self.assertRaises(ValueError):
+            utils.construct_account_rn("accounts/abc")
+        with self.assertRaises(ValueError):
+            utils.construct_data_stream_rn(252198517, "")
+        with self.assertRaises(ValueError):
+            utils.construct_key_event_rn(252198517, "")
+        with self.assertRaises(ValueError):
+            utils.construct_conversion_event_rn(252198517, "")
+        with self.assertRaises(ValueError):
+            utils.construct_custom_dimension_rn(252198517, "")
+        with self.assertRaises(ValueError):
+            utils.construct_custom_metric_rn(252198517, "")
+        with self.assertRaises(ValueError):
+            utils.construct_audience_export_rn(252198517, "")


### PR DESCRIPTION
## Summary
- add additional safe read-only admin and reporting tools for GA4
- add live validation and SDK-vs-MCP read-surface audit scripts
- document the exposed tool surface and the intentional secret-related omissions

## Validation
- uv run --with pytest python -m pytest -q tests
- live validation against GA4 property 252198517
- read-surface audit now reports unexplained_missing_count = 0

## Notes
Measurement protocol secret reads remain intentionally excluded from the MCP surface.