### PR TITLE
Use package metadata for MCP server version

### DIFF
--- a/analytics_mcp/server.py
+++ b/analytics_mcp/server.py
@@ -17,6 +17,7 @@
 """Entry point for the Google Analytics MCP server."""
 
 import asyncio
+from importlib import metadata
 import sys
 import analytics_mcp.coordinator as coordinator
 from mcp.server.lowlevel import NotificationOptions
@@ -24,6 +25,14 @@ from mcp.server.models import InitializationOptions
 import mcp.server.stdio
 import mcp.server
 import traceback
+
+
+def _server_version() -> str:
+    """Returns the installed package version with a safe fallback."""
+    try:
+        return metadata.version("analytics-mcp")
+    except metadata.PackageNotFoundError:
+        return "unknown"
 
 
 async def run_server_async():
@@ -35,7 +44,7 @@ async def run_server_async():
             write_stream,
             InitializationOptions(
                 server_name=coordinator.app.name,  # Use the server name defined above
-                server_version="1.0.0",
+                server_version=_server_version(),
                 capabilities=coordinator.app.get_capabilities(
                     # Define server capabilities - consult MCP docs for options
                     notification_options=NotificationOptions(),

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import patch
+
+from analytics_mcp import server
+
+
+class ServerVersionTest(unittest.TestCase):
+    @patch("analytics_mcp.server.metadata.version", return_value="0.6.0")
+    def test_server_version_uses_installed_package_version(self, version_mock):
+        self.assertEqual(server._server_version(), "0.6.0")
+        version_mock.assert_called_once_with("analytics-mcp")
+
+    @patch(
+        "analytics_mcp.server.metadata.version",
+        side_effect=server.metadata.PackageNotFoundError,
+    )
+    def test_server_version_falls_back_when_package_metadata_missing(
+        self, version_mock
+    ):
+        self.assertEqual(server._server_version(), "unknown")
+        version_mock.assert_called_once_with("analytics-mcp")


### PR DESCRIPTION
## Summary
- replace the hard-coded MCP server version with installed package metadata
- fall back to unknown when package metadata is unavailable
- add a focused unit test for the version helper

## Why
Codex and other MCP clients surface the server version during initialization. Returning the installed package version is more accurate than a fixed placeholder and makes the handshake easier to reason about during validation.