### PR TITLE
feat: add streamable HTTP transport support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build and Test Project
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  build-test-push:
+    name: Build and Test Project
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -e .[dev]
+
+      - name: Check formatting
+        run: nox -s lint
+
+      - name: Run tests
+        run: nox -s tests-3.11

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,17 @@
+name: Deploy To Testing
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-service-test:
+    name: Deploy Service To Testing
+    uses: phaeth-com/phaeth-cicd/.github/workflows/deploy-to-screen.yml@main
+    with:
+      screen: google-analytics-mcp-test
+      test: false
+      cmd: 'git checkout main && git -c core.sshCommand="ssh -i ~/.ssh/github-phaeth -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new" pull && pip install -e . && python analytics_mcp/server.py --http --host 127.0.0.1 --port 8880 --path /mcp'
+      healthcheck_endpoint: 'http://localhost:8880'
+    secrets: inherit

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -2,9 +2,10 @@
 permissions: read-all
 name: Presubmit
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - main
 jobs:
   test:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ pylintrc
 pylintrc.test
 
 .agents/skills
+
+.env

--- a/.trae/documents/streamable_http_mcp_server_plan.md
+++ b/.trae/documents/streamable_http_mcp_server_plan.md
@@ -1,0 +1,225 @@
+# Plan: Add Streamable HTTP Transport with Refresh Token Auth to Google Analytics MCP Server
+
+## 1. Repo Research Conclusion
+
+### Current Architecture
+
+The project is a Python MCP server for Google Analytics 4 (GA4) using the `mcp>=1.24.0` SDK's low-level `Server` class.
+
+**Key files:**
+
+* [server.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/server.py) — STDIO-only entry point, wires `stdio_server()` streams to `coordinator.app.run()`
+
+* [coordinator.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/coordinator.py) — Singleton low-level `Server("Google Analytics MCP Server")`. Registers 9 ADK `FunctionTool`s. Decorated handlers: `@app.list_tools()`, `@app.call_tool(name, arguments)` (no context parameter today).
+
+* [tools/client.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/client.py) — Global credential cache (`_CREDENTIALS`) + 4 factory fns:
+
+  * `create_admin_api_client()` → `AnalyticsAdminServiceClient`
+
+  * `create_data_api_client()` → `BetaAnalyticsDataClient`
+
+  * `create_admin_alpha_api_client()` → `AnalyticsAdminServiceClient` (alpha)
+
+  * `create_data_api_alpha_client()` → `AlphaAnalyticsDataClient`
+    All obtain credentials from `google.auth.default(scopes=[analytics.readonly])`.
+
+* Tool files (call factories module-level, no args):
+
+  * [tools/admin/info.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/admin/info.py)
+
+  * [tools/reporting/core.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/reporting/core.py)
+
+  * [tools/reporting/realtime.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/reporting/realtime.py)
+
+  * [tools/reporting/metadata.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/reporting/metadata.py)
+
+  * [tools/reporting/funnel.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/reporting/funnel.py)
+
+  * [tools/reporting/conversions.py](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/analytics_mcp/tools/reporting/conversions.py)
+
+* [pyproject.toml](file:///Users/peterwong/Documents/projects/phaeth/google-analytics-mcp/pyproject.toml) — Dependencies: `mcp>=1.24.0`, `google-auth~=2.40`, `httpx>=0.28.1`. Entry script: `analytics-mcp = analytics_mcp.server:run_server`.
+
+### MCP SDK Streamable HTTP Capability
+
+The installed low-level `Server` exposes `streamable_http_app(streamable_http_path="/mcp", ...) -> Starlette`, returning a ready-made Starlette ASGI app. It uses `StreamableHTTPSessionManager` and mounts the MCP endpoint at the configured path. The per-request `ServerRequestContext` carries `ctx.request` (the raw Starlette `Request`) whose `.headers` gives access to inbound HTTP headers. Transport-level headers are also set on `DispatchContext.transport.headers`.
+
+### Google Auth Equivalent for "authorized\_user" Refresh Token
+
+In Python (parallel to the Node.js pattern the user showed):
+
+```python
+from google.oauth2.credentials import Credentials as OAuth2UserCreds
+
+credentials = OAuth2UserCreds.from_authorized_user_info(
+    info={
+        # "type": "authorized_user" NOT required by from_authorized_user_info();
+        # the three keys below are the required minimum.
+        "client_id":     os.environ["GOOGLE_ANALYTICS_CLIENT_ID"],
+        "client_secret": os.environ["GOOGLE_ANALYTICS_CLIENT_SECRET"],
+        "refresh_token": <from HTTP header>,
+    },
+    scopes=["https://www.googleapis.com/auth/analytics.readonly"],
+)
+```
+
+Then pass `credentials=` to every `BetaAnalyticsDataClient(...)` / `AnalyticsAdminServiceClient(...)` constructor.
+
+### Request-Scoped Credential Propagation Challenge
+
+Tools call `create_*_api_client()` with zero arguments from inside `asyncio.to_thread(_sync_call)` workers. Thread workers need access to the request's refresh token.
+
+**Chosen approach:** **`contextvars.ContextVar`** — Python's `contextvars` correctly propagates through `asyncio` tasks *and* `asyncio.to_thread()` workers in Py 3.9+. A `ServerMiddleware` reads the header, sets the ContextVar, and `create_*_api_client()` uses it to build user credentials before falling back to `google.auth.default()`.
+
+***
+
+## 2. Files and Modules to Be Edited
+
+| # | File                            | Change Type                                                                                                                                                                                      |
+| - | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 | `analytics_mcp/tools/client.py` | Modify — add ContextVar + refresh-token credential builder; add optional `credentials` parameter to client factory fns                                                                           |
+| 2 | `analytics_mcp/coordinator.py`  | Modify — add middleware that extracts `x-ga-refresh-token` header and sets ContextVar; update `@app.call_tool` signature to receive `ServerRequestContext` (so middleware is active on the path) |
+| 3 | `analytics_mcp/server.py`       | Modify — add `run_http_server_async()` + Starlette/uvicorn runner on `/mcp` path; keep STDIO runner as default                                                                                   |
+| 4 | `pyproject.toml`                | Modify — add `uvicorn` (or `hypercorn`) dep and new `analytics-mcp-http` entry script                                                                                                            |
+
+Optionally touched (no logic changes, only new imports): tool files under `tools/admin` and `tools/reporting` if client function signature changes — but we'll keep backward-compatible defaults so they are unaffected.
+
+***
+
+## 3. Steps for Modifications or New Features
+
+### Step 3.1 — Add per-request refresh token context and credential builder (`client.py`)
+
+1. **New imports:** `contextvars`, `os`, `google.oauth2.credentials`.
+2. **Add a ContextVar:**
+
+   ```python
+   _refresh_token_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+       "ga_refresh_token", default=None
+   )
+   ```
+
+   Expose module-level `set_refresh_token(token)` / `clear_refresh_token()` helpers for middleware use.
+3. **Add** **`_build_authorized_user_credentials(refresh_token: str)`** **helper:**
+
+   * Reads `GOOGLE_ANALYTICS_CLIENT_ID` and `GOOGLE_ANALYTICS_CLIENT_SECRET` from env.
+
+   * Raises a clear error if either env var is missing (actionable error message).
+
+   * Calls `google.oauth2.credentials.Credentials.from_authorized_user_info(info={"client_id","client_secret","refresh_token"}, scopes=[_READ_ONLY_ANALYTICS_SCOPE])`.
+4. **Rework** **`_get_credentials()`** **to be request-aware:**
+
+   * Remove the `global _CREDENTIALS` singleton path (or keep it as stdio/local fallback only).
+
+   * New logic:
+
+     1. `tok = _refresh_token_ctx.get()` → if set, return `_build_authorized_user_credentials(tok)` (no caching needed; google-oauth2 caches access token on the creds object).
+     2. Otherwise use the existing `google.auth.default()` path cached via `_CREDENTIALS` for STDIO mode.
+
+   * Keep `_client_lock` for the `google.auth.default()` leg only.
+5. **Update the 4 client factory signatures** to keep them backward compatible with tool call sites:
+
+   * `def create_admin_api_client(credentials=None) -> ...`
+
+   * Same for `create_data_api_client`, `create_admin_alpha_api_client`, `create_data_api_alpha_client`.
+
+   * Body: if `credentials` passed use it, else call `_get_credentials()` (which reads the ContextVar or falls back to ADC).
+
+   * Tool call sites need **zero edits** because defaults apply.
+
+### Step 3.2 — Middleware to pull refresh token from HTTP header (`coordinator.py`)
+
+1. **New imports:** `ServerMiddleware` from `mcp.server.context`, `ServerRequestContext`, `set_refresh_token` / `clear_refresh_token` from `analytics_mcp.tools.client`.
+2. **Header name:** Use `x-ga-refresh-token` (configurable via env if desired). Document that this header is the carrier for the Google OAuth refresh token.
+3. **Middleware fn:**
+
+   ```python
+   async def refresh_token_middleware(ctx, call_next):
+       tok = None
+       req = ctx.request  # Starlette Request on streamable HTTP
+       if req is not None and hasattr(req, "headers"):
+           tok = req.headers.get("x-ga-refresh-token")
+           # Also try canonical forms (case-insensitive via .get() already in Starlette)
+       if tok:
+           token = set_refresh_token(tok)
+           try:
+               return await call_next(ctx)
+           finally:
+               clear_refresh_token(token)
+       else:
+           return await call_next(ctx)
+   ```
+4. **Register middleware on the low-level Server:** append `refresh_token_middleware` to `app.middleware` after constructing `app = Server(...)`.
+5. **Update** **`@app.call_tool`** **handler signature** so it takes `ctx: ServerRequestContext` explicitly (even if unused) — this guarantees the middleware chain is correctly wired for tool invocations on the low-level Server. Keep existing logic intact but ensure the signature change is compatible. If the decorator in the installed SDK doesn't support context arg transparently, fall back to register via `on_call_tool=` in the constructor.
+
+### Step 3.3 — Streamable HTTP server entry point (`server.py`)
+
+1. **New imports:** `os`, `uvicorn` (or hypercorn). Import `coordinator.app`.
+2. **New coroutine** **`run_http_server_async(host, port, path="/mcp")`:**
+
+   * Build ASGI app: `starlette_app = coordinator.app.streamable_http_app(streamable_http_path=path, host=host)`
+
+   * Run under uvicorn programmatically via `uvicorn.Server(Config(...))` inside `anyio.run` / `asyncio.run`, matching the transport=streamable-http pattern from `MCPServer.run_streamable_http_async`.
+
+   * Or simply: use the low-level Server's `run(transport="streamable-http", ...)` if the SDK version exports it on the low-level Server; the installed SDK exposes `streamable_http_app()` which can be fed into any ASGI runner.
+3. **New sync** **`run_http_server()`** **wrapper** mirroring `run_server()`.
+4. **Entry-point CLI switch:** allow running mode via env `ANALYTICS_MCP_TRANSPORT=stdio|http` or argv — if argv says `--http` or transport env is `http`, start HTTP server; otherwise STDIO (preserves backward compat).
+5. Print startup banner with transport mode + endpoint URL on stderr for visibility.
+
+### Step 3.4 — Project manifest updates (`pyproject.toml`)
+
+1. Add an `[project.optional-dependencies]` extra `http` that includes `uvicorn>=0.30.0, starlette>=0.40.0` (starlette should already be a transitive dep of `mcp`, but pinning is safe).
+2. New script entry:
+
+   ```toml
+   analytics-mcp-http = "analytics_mcp.server:run_http_server"
+   ```
+
+   Keep the existing `analytics-mcp` script bound to `run_server` (stdio by default, env-switchable).
+
+### Step 3.5 — Validation / verification steps
+
+1. **Syntax:** `python -m compileall analytics_mcp/` — should exit 0.
+2. **Imports smoke test:** `python -c "from analytics_mcp.tools.client import create_data_api_client; from analytics_mcp import coordinator; from analytics_mcp.server import run_http_server"` — no exceptions.
+3. **Credential builder unit test (no network):** set env `GOOGLE_ANALYTICS_CLIENT_ID=id`, `GOOGLE_ANALYTICS_CLIENT_SECRET=secret`, set refresh token ContextVar, call `_get_credentials()` and assert a `google.oauth2.credentials.Credentials` instance is returned with correct scopes.
+4. **HTTP smoke run (no real GA4):** start `ANALYTICS_MCP_TRANSPORT=http analytics-mcp-http`, curl `POST /mcp` with a valid JSON-RPC initialize request; include dummy `x-ga-refresh-token` header and verify the middleware runs (add a debug log if needed). Expect the MCP handshake to proceed (tool calls will fail on actual Google APIs if token is invalid — that's expected).
+
+***
+
+## 4. Potential Dependencies or Considerations
+
+* **`uvicorn`** **/** **`hypercorn`** **ASGI runner** — needed to actually serve the Starlette app. Added as an optional extra (`[http]`). Starlette itself is already a dependency of the `mcp` SDK, so runtime import is guaranteed.
+
+* **Env vars required for HTTP mode:** `GOOGLE_ANALYTICS_CLIENT_ID`, `GOOGLE_ANALYTICS_CLIENT_SECRET`. The middleware path will error at credential-construction time if either is unset while a refresh-token header is present. Provide clear, actionable error text including the name of the missing variable.
+
+* **Case-insensitive header lookup:** Starlette `Request.headers` already performs case-insensitive lookups for HTTP/1.x. Use header name exactly as documented (we pick `x-ga-refresh-token`) and note it in the code comment.
+
+* **`asyncio.to_thread`** **+** **`contextvars`:** Python 3.9+ propagates contextvars into `to_thread` workers automatically. Project requires `>=3.10`, so this is guaranteed. Verified behavior on 3.10/3.11 by CPython release notes.
+
+* **Global** **`_CREDENTIALS`** **+ request-scoped creds coexistence:** Keep the global cache only for the `google.auth.default()` fallback. Never cache per-request refresh-token-derived credentials in a module global — that would leak credentials across users. They live for the request only and are GC'd after.
+
+* **Thread-safety of the ContextVar approach:** ContextVar values are per (async) task and per thread, so concurrent requests are fully isolated. No additional lock needed.
+
+* **`tool.run_async(..., tool_context=None)`** **in coordinator:** Currently passes `None` — ADK `tool_context` isn't used here, so this remains unchanged; the ContextVar carries the credential info for the Google client libraries underneath.
+
+* **Streamable HTTP transport stateless vs stateful:** Default `stateless_http=False` on the SDK — fine for an LLM-facing server. If high horizontal scale is needed later, enable stateless mode and re-test tool behavior (the tools themselves are stateless — no session state stored server-side — so enabling stateless should work without code changes).
+
+* **`prevent_stdio_inheritance()`** **deadlock fix:** Still applicable to the `google.auth.default()` path. For the authorized-user credential path (direct OAuth2 refresh), no subprocess is spawned; only HTTP calls happen via `httpx`. The `prevent_stdio_inheritance` context manager can be removed from the new leg — keep it wrapped around the `google.auth.default()` call only.
+
+* **Security — logging:** Never log the refresh token or client secret. Make sure error messages exclude the actual token values.
+
+* **Backward compatibility:** The existing STDIO entry point (`analytics-mcp` script) must keep working 100% as before with Application Default Credentials. No env vars are required when running in STDIO mode.
+
+***
+
+## 5. Risk Handling
+
+| Risk                                                                                                                                 | Likelihood | Impact   | Mitigation                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Installed `mcp` SDK version's `@app.call_tool` decorator doesn't accept the `ServerRequestContext` arg (older lowlevel API mismatch) | Medium     | High     | Fall back: use `on_call_tool=` kwarg in Server constructor instead of decorator. If middleware runs before dispatch, the ContextVar is already set, so even a no-context handler still observes correct credentials. The header extraction lives in middleware, not in the handler — handler signature is irrelevant for credential propagation. |
+| Starlette `ctx.request` is `None` for legacy handshake on streamable HTTP                                                            | Medium     | Low      | Handshake messages (`initialize`) don't invoke tools, so no credentials are needed. Middleware only sets ContextVar when `ctx.request is not None and hasattr(req, "headers")`. Tool calls on the modern era always carry the request.                                                                                                           |
+| Missing `GOOGLE_ANALYTICS_CLIENT_ID`/`CLIENT_SECRET` env vars at runtime when refresh token header is supplied                       | High       | Medium   | Throw `ValueError` from `_build_authorized_user_credentials` with the exact env var names. Wrap the call in the middleware (or at credential-build time) so the error is returned to the caller as an MCP tool error text, not an HTTP 500.                                                                                                      |
+| Caching per-request credentials globally across users → data leak                                                                    | High       | Critical | Explicitly: never store ContextVar-built credentials on module globals. The `_CREDENTIALS` module cache is ONLY populated by the `google.auth.default()` fallback branch. Locks on `_client_lock` protect only the global fallback branch.                                                                                                       |
+| `asyncio.to_thread` loses ContextVar on 3.10 edge cases                                                                              | Low        | High     | Explicitly verify by unit test or REPL: set var, schedule a to\_thread fn that reads it, assert equality. If failure observed, wrap thread entry via `contextvars.copy_context().run(...)` manually using `asyncio.get_event_loop().run_in_executor` with a context-bound callable.                                                              |
+| `uvicorn` not installed when user runs `analytics-mcp-http`                                                                          | Medium     | Medium   | Catch `ModuleNotFoundError` for `uvicorn` at import time inside `run_http_server` and print a one-line install hint: `pip install "analytics-mcp[http]"`. Document in the script entry that the extra is required.                                                                                                                               |
+| `host=0.0.0.0` on streamable\_http\_app disables DNS-rebinding protection built into SDK                                             | Low        | Medium   | Pass the actual `host` arg through to `streamable_http_app(host=host, transport_security=...)` so the SDK's auto-configuration stays engaged. Default host for HTTP mode to `127.0.0.1` (same as the SDK default); only bind `0.0.0.0` if the user explicitly passes it via env/CLI.                                                             |
+

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -21,13 +21,24 @@ server.
 # MCP Server Imports
 import json
 import sys
-from json import tool
+
 from mcp import types as mcp_types  # Use alias to avoid conflict
+from mcp.server.context import (
+    CallNext,
+    HandlerResult,
+    ServerRequestContext,
+)
 from mcp.server.lowlevel import Server
 
 # ADK Tool Imports
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.mcp_tool.conversion_utils import adk_to_mcp_tool_type
+
+from analytics_mcp.tools.client import (
+    REFRESH_TOKEN_HEADER,
+    clear_refresh_token,
+    set_refresh_token,
+)
 
 from analytics_mcp.tools.admin.info import (
     get_account_summaries,
@@ -85,9 +96,6 @@ tools = [
 
 tool_map = {t.name: t for t in tools}
 
-app = Server(
-    name="Google Analytics MCP Server",
-)
 
 mcp_tools = [adk_to_mcp_tool_type(tool) for tool in tools]
 
@@ -117,33 +125,36 @@ def sanitize_mcp_schema_properties(node: dict) -> None:
                     sanitize_mcp_schema_properties(element)
 
 
-# Update the inputSchema for tools that do not have parameters.
+# Update the input_schema for tools that do not have parameters.
+# NOTE: The Pydantic field on mcp_types.Tool is `input_schema` (Python
+# attribute) with wire alias `inputSchema`. Programmatically we always use
+# the Python attribute name.
 # TODO: This is a bug in the ADK and can be removed once it is fixed.
 # https://github.com/google/adk-python/issues/948
 for tool in mcp_tools:
-    # Check if inputSchema is empty
-    if tool.inputSchema == {}:
-        tool.inputSchema = {"type": "object", "properties": {}}
+    # Check if input_schema is empty
+    if tool.input_schema == {}:
+        tool.input_schema = {"type": "object", "properties": {}}
     # Fix union type hints generating spurious "type": "null"
-    for prop in tool.inputSchema.get("properties", {}).values():
+    for prop in tool.input_schema.get("properties", {}).values():
         if "anyOf" in prop and prop.get("type") == "null":
             del prop["type"]
 
     # Ensure additionalProperties is compatible with all MCP clients
-    sanitize_mcp_schema_properties(tool.inputSchema)
+    sanitize_mcp_schema_properties(tool.input_schema)
 
     # Explicitly mark required fields for reporting tools to guide the LLM
     if tool.name == "run_report":
-        tool.inputSchema["required"] = [
+        tool.input_schema["required"] = [
             "property_id",
             "date_ranges",
             "dimensions",
             "metrics",
         ]
     elif tool.name == "run_realtime_report":
-        tool.inputSchema["required"] = ["property_id", "dimensions", "metrics"]
+        tool.input_schema["required"] = ["property_id", "dimensions", "metrics"]
     elif tool.name == "run_conversions_report":
-        tool.inputSchema["required"] = [
+        tool.input_schema["required"] = [
             "property_id",
             "date_ranges",
             "dimensions",
@@ -152,13 +163,25 @@ for tool in mcp_tools:
         ]
 
 
-@app.list_tools()
-async def list_tools() -> list[mcp_types.Tool]:
-    return mcp_tools
+# ---- MCP request handlers -------------------------------------------------
 
 
-@app.call_tool()
-async def call_mcp_tool(name: str, arguments: dict) -> list[mcp_types.Content]:
+async def _handle_list_tools(
+    ctx: ServerRequestContext,
+    params: mcp_types.PaginatedRequestParams | None,
+) -> mcp_types.ListToolsResult:
+    """Handler for the MCP tools/list request."""
+    return mcp_types.ListToolsResult(tools=mcp_tools)
+
+
+async def _handle_call_tool(
+    ctx: ServerRequestContext,
+    params: mcp_types.CallToolRequestParams,
+) -> mcp_types.CallToolResult:
+    """Handler for the MCP tools/call request."""
+    name = params.name
+    arguments = params.arguments or {}
+
     if name in tool_map:
         tool = tool_map[name]
         try:
@@ -166,23 +189,73 @@ async def call_mcp_tool(name: str, arguments: dict) -> list[mcp_types.Content]:
                 args=arguments,
                 tool_context=None,
             )
-            # Serialize the ADK tool response to JSON for MCP response
             response_text = json.dumps(adk_tool_response, indent=2)
-            # MCP expects a list of mcp_types.Content parts
-            return [mcp_types.TextContent(type="text", text=response_text)]
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=response_text)]
+            )
 
         except Exception as e:
             print(
                 f"MCP Server: Error executing ADK tool '{name}': {e}",
                 file=sys.stderr,
             )
-            # Return an error message in MCP format
             error_text = json.dumps(
                 {"error": f"Failed to execute tool '{name}': {str(e)}"}
             )
-            return [mcp_types.TextContent(type="text", text=error_text)]
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=error_text)],
+                is_error=True,
+            )
 
     error_text = json.dumps(
         {"error": f"Tool '{name}' not implemented by this server."}
     )
-    return [mcp_types.TextContent(type="text", text=error_text)]
+    return mcp_types.CallToolResult(
+        content=[mcp_types.TextContent(type="text", text=error_text)],
+        is_error=True,
+    )
+
+
+# ---- Middleware -----------------------------------------------------------
+
+
+async def refresh_token_middleware(
+    ctx: ServerRequestContext,
+    call_next: CallNext,
+) -> HandlerResult:
+    """Server middleware that extracts a Google OAuth refresh token from the
+    inbound HTTP request header (x-ga-refresh-token) and places it into the
+    request-scoped ContextVar.
+
+    The ContextVar is read by the Google client factory functions in
+    :mod:`analytics_mcp.tools.client` when building credentials.
+
+    No-op when running over STDIO or when the header is absent.
+    """
+    request = ctx.request
+    refresh_token = None
+    if request is not None and hasattr(request, "headers"):
+        refresh_token = request.headers.get(REFRESH_TOKEN_HEADER)
+
+    if refresh_token:
+        token = set_refresh_token(refresh_token)
+        try:
+            return await call_next(ctx)
+        finally:
+            clear_refresh_token(token)
+    else:
+        return await call_next(ctx)
+
+
+# ---- Server construction --------------------------------------------------
+
+app = Server(
+    name="Google Analytics MCP Server",
+    on_list_tools=_handle_list_tools,
+    on_call_tool=_handle_call_tool,
+)
+
+# Register as the outermost user middleware. SDK's built-ins run inside it so
+# the refresh token context is available for all user handlers including
+# list_tools and call_tool.
+app.middleware.append(refresh_token_middleware)

--- a/analytics_mcp/server.py
+++ b/analytics_mcp/server.py
@@ -14,16 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Entry point for the Google Analytics MCP server."""
+"""Entry point for the Google Analytics MCP server.
 
+Supports two transports:
+
+* **STDIO** (default) — interop with local MCP clients over process pipes.
+* **Streamable HTTP** — remote deployment; serves the MCP protocol on an
+  HTTP endpoint (``POST /mcp``). Pass ``--http`` or set the environment
+  variable ``ANALYTICS_MCP_TRANSPORT=http`` to enable it.
+
+When using the HTTP transport, callers must include the
+``x-ga-refresh-token`` header on every request carrying a valid Google OAuth
+refresh token for the authorized user. The server builds per-request
+``authorized_user`` credentials from
+``GOOGLE_ANALYTICS_CLIENT_ID``/``GOOGLE_ANALYTICS_CLIENT_SECRET`` (required
+environment variables) and the header value.
+"""
+
+import argparse
 import asyncio
+import os
 import sys
+import traceback
+from dotenv import load_dotenv
+
 import analytics_mcp.coordinator as coordinator
+import mcp.server
+import mcp.server.stdio
 from mcp.server.lowlevel import NotificationOptions
 from mcp.server.models import InitializationOptions
-import mcp.server.stdio
-import mcp.server
-import traceback
+
+# ---- Transport selection -------------------------------------------------
+
+_TRANSPORT_STDIO = "stdio"
+_TRANSPORT_HTTP = "http"
+_VALID_TRANSPORTS = (_TRANSPORT_STDIO, _TRANSPORT_HTTP)
+
+load_dotenv()
+
+def _resolve_transport(cli_http_flag: bool) -> str:
+    """Pick a transport based on CLI flag then env var. Defaults to stdio."""
+    if cli_http_flag:
+        return _TRANSPORT_HTTP
+    env = os.getenv("ANALYTICS_MCP_TRANSPORT", _TRANSPORT_STDIO).lower()
+    if env not in _VALID_TRANSPORTS:
+        print(
+            f"Warning: unknown ANALYTICS_MCP_TRANSPORT value {env!r}; "
+            f"falling back to '{_TRANSPORT_STDIO}'.",
+            file=sys.stderr,
+        )
+        return _TRANSPORT_STDIO
+    return env
+
+
+# ---- STDIO transport ------------------------------------------------------
 
 
 async def run_server_async():
@@ -34,10 +78,9 @@ async def run_server_async():
             read_stream,
             write_stream,
             InitializationOptions(
-                server_name=coordinator.app.name,  # Use the server name defined above
+                server_name=coordinator.app.name,
                 server_version="1.0.0",
                 capabilities=coordinator.app.get_capabilities(
-                    # Define server capabilities - consult MCP docs for options
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},
                 ),
@@ -46,19 +89,125 @@ async def run_server_async():
 
 
 def run_server():
-    """Synchronous wrapper to run the async MCP server."""
-    asyncio.run(run_server_async())
+    """Synchronous wrapper to run the async MCP server (stdio by default).
 
+    If ``ANALYTICS_MCP_TRANSPORT=http`` or ``--http`` was passed on the
+    command line, this delegates to :func:`run_http_server` instead.
+    """
+    parser = argparse.ArgumentParser(
+        description="Google Analytics MCP Server.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        default=False,
+        help="Run the streamable HTTP transport (serves /mcp).",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("ANALYTICS_MCP_HTTP_HOST", "127.0.0.1"),
+        help="Bind host for HTTP transport (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("ANALYTICS_MCP_HTTP_PORT", "8000")),
+        help="Bind port for HTTP transport (default: 8000).",
+    )
+    parser.add_argument(
+        "--path",
+        default=os.getenv("ANALYTICS_MCP_HTTP_PATH", "/mcp"),
+        help="URL path for the MCP HTTP endpoint (default: /mcp).",
+    )
+    args, _unknown = parser.parse_known_args()
+
+    transport = _resolve_transport(args.http)
+    if transport == _TRANSPORT_HTTP:
+        run_http_server(host=args.host, port=args.port, path=args.path)
+    else:
+        asyncio.run(run_server_async())
+
+
+# ---- Streamable HTTP transport -------------------------------------------
+
+
+async def run_http_server_async(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/mcp",
+) -> None:
+    """Run the MCP server using the streamable HTTP transport.
+
+    Args:
+        host: Interface address to bind to.
+        port: TCP port to bind to.
+        path: URL path that serves the MCP protocol (``POST`` + SSE).
+    """
+    try:
+        import uvicorn  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - install hint
+        raise ModuleNotFoundError(
+            "The 'uvicorn' package is required for the HTTP transport. "
+            'Install it with: pip install "analytics-mcp[http]"'
+        ) from exc
+
+    # Validate required env vars early for a clear error on startup.
+    missing: list[str] = []
+    if not os.getenv("GOOGLE_ANALYTICS_CLIENT_ID"):
+        missing.append("GOOGLE_ANALYTICS_CLIENT_ID")
+    if not os.getenv("GOOGLE_ANALYTICS_CLIENT_SECRET"):
+        missing.append("GOOGLE_ANALYTICS_CLIENT_SECRET")
+    if missing:
+        print(
+            "HTTP transport requires the following environment variables to "
+            "build authorized_user credentials from the x-ga-refresh-token "
+            "header: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+
+    starlette_app = coordinator.app.streamable_http_app(
+        streamable_http_path=path,
+        host=host,
+    )
+
+    url = f"http://{host}:{port}{path}"
+    print(
+        f"Starting MCP Streamable HTTP Server: {coordinator.app.name} "
+        f"on {url}",
+        file=sys.stderr,
+    )
+    config = uvicorn.Config(
+        starlette_app,
+        host=host,
+        port=port,
+        log_level="info",
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+def run_http_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/mcp",
+) -> None:
+    """Synchronous wrapper around :func:`run_http_server_async`."""
+    asyncio.run(run_http_server_async(host=host, port=port, path=path))
+
+
+# ---- __main__ dispatcher --------------------------------------------------
 
 if __name__ == "__main__":
     try:
         run_server()
     except KeyboardInterrupt:
-        print("\nMCP Server (stdio) stopped by user.", file=sys.stderr)
+        print(
+            "\nMCP Server stopped by user (keyboard interrupt).",
+            file=sys.stderr,
+        )
     except Exception:
-        import traceback
-
-        print("MCP Server (stdio) encountered an error:", file=sys.stderr)
+        print("MCP Server encountered an error:", file=sys.stderr)
         traceback.print_exc()
     finally:
-        print("MCP Server (stdio) process exiting.", file=sys.stderr)
+        print("MCP Server process exiting.", file=sys.stderr)

--- a/analytics_mcp/tools/client.py
+++ b/analytics_mcp/tools/client.py
@@ -15,6 +15,8 @@
 """Client initialization for the Google Analytics APIs."""
 
 import contextlib
+import contextvars
+import os
 import subprocess
 import threading
 from importlib import metadata
@@ -23,11 +25,12 @@ from unittest.mock import patch
 import google.auth
 from google.analytics import (
     admin_v1beta,
-    data_v1beta,
     admin_v1alpha,
     data_v1alpha,
+    data_v1beta,
 )
 from google.api_core.gapic_v1.client_info import ClientInfo
+from google.oauth2 import credentials as oauth2_credentials
 
 
 def _get_package_version_with_fallback():
@@ -55,6 +58,31 @@ _READ_ONLY_ANALYTICS_SCOPE = (
 _client_lock = threading.Lock()
 _CREDENTIALS = None
 
+# Per-request refresh token context. Populated by middleware from HTTP header
+# x-ga-refresh-token when running over streamable-HTTP transport. Propagates
+# correctly across asyncio tasks and asyncio.to_thread() workers.
+_refresh_token_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "ga_refresh_token", default=None
+)
+
+# Header name used to carry the Google OAuth refresh token on inbound HTTP
+# requests to the streamable-HTTP MCP endpoint.
+REFRESH_TOKEN_HEADER = "x-ga-refresh-token"
+
+
+def set_refresh_token(refresh_token: str) -> contextvars.Token:
+    """Set the request-scoped OAuth refresh token.
+
+    Returns the contextvars Token so the caller can reset the variable using
+    :func:`clear_refresh_token` after the request is complete.
+    """
+    return _refresh_token_ctx.set(refresh_token)
+
+
+def clear_refresh_token(token: contextvars.Token) -> None:
+    """Reset the request-scoped refresh token using a prior Token."""
+    _refresh_token_ctx.reset(token)
+
 
 @contextlib.contextmanager
 def prevent_stdio_inheritance():
@@ -75,46 +103,140 @@ def prevent_stdio_inheritance():
         yield
 
 
-def _get_credentials():
+def _build_authorized_user_credentials(refresh_token: str):
+    """Build Google OAuth credentials using a user-supplied refresh token.
+
+    Equivalent in intent to the Node.js pattern:
+
+        credentials = {
+            type: "authorized_user",
+            client_id: process.env.GOOGLE_ANALYTICS_CLIENT_ID,
+            client_secret: process.env.GOOGLE_ANALYTICS_CLIENT_SECRET,
+            refresh_token: <refresh_token>,
+        }
+
+    Raises ValueError with actionable message if either required env var is
+    missing.
+    """
+    client_id = os.getenv("GOOGLE_ANALYTICS_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_ANALYTICS_CLIENT_SECRET")
+    missing: list[str] = []
+    if not client_id:
+        missing.append("GOOGLE_ANALYTICS_CLIENT_ID")
+    if not client_secret:
+        missing.append("GOOGLE_ANALYTICS_CLIENT_SECRET")
+    if missing:
+        raise ValueError(
+            "Cannot build Google authorized_user credentials: missing "
+            "required environment variable(s): "
+            + ", ".join(missing)
+            + ". Please set these environment variables on the server process."
+        )
+
+    return oauth2_credentials.Credentials.from_authorized_user_info(
+        info={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        },
+        scopes=[_READ_ONLY_ANALYTICS_SCOPE],
+    )
+
+
+def _get_default_credentials_cached():
+    """Return the application-default credentials, cached in-process.
+
+    Used as the fallback when no per-request refresh token is present (e.g.
+    running over STDIO transport). Thread-safe.
+    """
     global _CREDENTIALS
-    # Expected to be called under _client_lock
     if _CREDENTIALS is None:
-        with prevent_stdio_inheritance():
-            _CREDENTIALS, _ = google.auth.default(
-                scopes=[_READ_ONLY_ANALYTICS_SCOPE]
-            )
+        with _client_lock:
+            if _CREDENTIALS is None:
+                with prevent_stdio_inheritance():
+                    _CREDENTIALS, _ = google.auth.default(
+                        scopes=[_READ_ONLY_ANALYTICS_SCOPE]
+                    )
     return _CREDENTIALS
 
 
-def create_admin_api_client() -> admin_v1beta.AnalyticsAdminServiceClient:
-    """Returns the Google Analytics Admin API client."""
-    with _client_lock:
-        return admin_v1beta.AnalyticsAdminServiceClient(
-            client_info=_CLIENT_INFO, credentials=_get_credentials()
-        )
+def _get_credentials():
+    """Return credentials for the current request.
+
+    Priority:
+      1. Per-request refresh token set via :func:`set_refresh_token`
+         (HTTP transport).
+      2. In-process cached application-default credentials
+         (STDIO transport / local development).
+
+    Per-request credentials are NOT cached module-globally to avoid leaking
+    credentials across users/requests.
+    """
+    refresh_token = _refresh_token_ctx.get()
+    if refresh_token:
+        return _build_authorized_user_credentials(refresh_token)
+    return _get_default_credentials_cached()
 
 
-def create_data_api_client() -> data_v1beta.BetaAnalyticsDataClient:
-    """Returns the Google Analytics Data API client."""
-    with _client_lock:
-        return data_v1beta.BetaAnalyticsDataClient(
-            client_info=_CLIENT_INFO, credentials=_get_credentials()
-        )
+def create_admin_api_client(
+    credentials=None,
+) -> admin_v1beta.AnalyticsAdminServiceClient:
+    """Returns the Google Analytics Admin API client.
+
+    Args:
+        credentials: Optional explicit credentials. If omitted, credentials
+            are resolved from the per-request refresh token context or the
+            application-default credentials cache.
+    """
+    creds = credentials if credentials is not None else _get_credentials()
+    return admin_v1beta.AnalyticsAdminServiceClient(
+        client_info=_CLIENT_INFO, credentials=creds
+    )
 
 
-def create_admin_alpha_api_client() -> (
-    admin_v1alpha.AnalyticsAdminServiceClient
-):
-    """Returns the Google Analytics Admin API (alpha) client."""
-    with _client_lock:
-        return admin_v1alpha.AnalyticsAdminServiceClient(
-            client_info=_CLIENT_INFO, credentials=_get_credentials()
-        )
+def create_data_api_client(
+    credentials=None,
+) -> data_v1beta.BetaAnalyticsDataClient:
+    """Returns the Google Analytics Data API client.
+
+    Args:
+        credentials: Optional explicit credentials. If omitted, credentials
+            are resolved from the per-request refresh token context or the
+            application-default credentials cache.
+    """
+    creds = credentials if credentials is not None else _get_credentials()
+    return data_v1beta.BetaAnalyticsDataClient(
+        client_info=_CLIENT_INFO, credentials=creds
+    )
 
 
-def create_data_api_alpha_client() -> data_v1alpha.AlphaAnalyticsDataClient:
-    """Returns the Google Analytics Data API (Alpha) client."""
-    with _client_lock:
-        return data_v1alpha.AlphaAnalyticsDataClient(
-            client_info=_CLIENT_INFO, credentials=_get_credentials()
-        )
+def create_admin_alpha_api_client(
+    credentials=None,
+) -> admin_v1alpha.AnalyticsAdminServiceClient:
+    """Returns the Google Analytics Admin API (alpha) client.
+
+    Args:
+        credentials: Optional explicit credentials. If omitted, credentials
+            are resolved from the per-request refresh token context or the
+            application-default credentials cache.
+    """
+    creds = credentials if credentials is not None else _get_credentials()
+    return admin_v1alpha.AnalyticsAdminServiceClient(
+        client_info=_CLIENT_INFO, credentials=creds
+    )
+
+
+def create_data_api_alpha_client(
+    credentials=None,
+) -> data_v1alpha.AlphaAnalyticsDataClient:
+    """Returns the Google Analytics Data API (Alpha) client.
+
+    Args:
+        credentials: Optional explicit credentials. If omitted, credentials
+            are resolved from the per-request refresh token context or the
+            application-default credentials cache.
+    """
+    creds = credentials if credentials is not None else _get_credentials()
+    return data_v1alpha.AlphaAnalyticsDataClient(
+        client_info=_CLIENT_INFO, credentials=creds
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,14 @@ issues = "https://github.com/googleanalytics/google-analytics-mcp/issues"
 
 [project.scripts]
 analytics-mcp = "analytics_mcp.server:run_server"
+# Streamable HTTP variant entry point.
+analytics-mcp-http = "analytics_mcp.server:run_http_server"
 # The previous name of the script. Kept for backwards compatibility.
 google-analytics-mcp = "analytics_mcp.server:run_server"
 
 [project.optional-dependencies]
 dev = ["black", "nox >=2026.2.9, <2027"]
+http = ["uvicorn>=0.30.0", "starlette>=0.40.0"]
 
 [build-system]
 requires = ["setuptools>=82.0.0", "wheel"]


### PR DESCRIPTION
This commit adds full streamable HTTP transport support to the Google Analytics MCP server, including:
- HTTP server implementation using uvicorn and starlette with CLI and environment variable configuration
- Middleware to extract Google OAuth refresh token from the `x-ga-refresh-token` HTTP header for per-request user authentication
- Reworked credential handling to support both application-default (stdio mode) and per-request user credentials (HTTP mode)
- Updated pyproject.toml with optional `http` dependency extra and new CLI entry point `analytics-mcp-http`
- Added GitHub CI workflows for presubmit checks, build/test, and deploy-to-testing environment
- Updated `.gitignore` to include `.env` and `.agents/skills` directories
- Fixed MCP tool input schema naming to use the Pythonic `input_schema` attribute instead of `inputSchema`
- Refactored server handler setup to use modern MCP low-level server patterns with middleware and request context