### PR TITLE
docs: fix env var name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Credentials saved to file: [PATH_TO_CREDENTIALS_JSON]
           "args": ["run", "analytics-mcp"],
           "env": {
             "GOOGLE_APPLICATION_CREDENTIALS": "PATH_TO_CREDENTIALS_JSON",
-            "GOOGLE_PROJECT_ID": "YOUR_PROJECT_ID"
+            "GOOGLE_CLOUD_PROJECT": "YOUR_PROJECT_ID"
           }
         }
       }
@@ -161,7 +161,7 @@ Credentials saved to file: [PATH_TO_CREDENTIALS_JSON]
     claude mcp add analytics-mcp \
       --scope user \
       -e "GOOGLE_APPLICATION_CREDENTIALS=PATH_TO_CREDENTIALS_JSON" \
-      -e "GOOGLE_PROJECT_ID=YOUR_PROJECT_ID" \
+      -e "GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID" \
       -- pipx run analytics-mcp
     ```
 


### PR DESCRIPTION
The correct env var name for the Google Cloud Project ID is `GOOGLE_CLOUD_PROJECT`.

https://github.com/googleapis/google-cloud-python/blob/f1213c311d6b8d96e46763cb0e3cff8b68f72f70/packages/google-auth/google/auth/environment_vars.py#L18