### PR TITLE
fix(server): drop the redundant inner traceback import (FR-174)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,9 +8,20 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+# Default-deny at the top level (Scorecard Token-Permissions); the analyze
+# job below re-grants exactly what CodeQL needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
-    name: Analyze
+    # PINNED DELIBERATELY — do not replace with a bare `name: Analyze`.
+    # GitHub derives an unnamed matrix job's title from ALL of its matrix
+    # keys, so adding a second key later silently renames this job. Where a
+    # branch ruleset requires "Analyze (actions)", a renamed job makes that
+    # rule UNSATISFIABLE rather than failing: PRs sit BLOCKED with every
+    # check green, and only the merge attempt names the missing context.
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -20,16 +31,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [actions]
+        # `actions` alone scans workflow YAML and ZERO application source.
+        language: [actions, python]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ pylintrc
 pylintrc.test
 
 .agents/skills
+.stargazer-*

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -54,6 +54,16 @@ from analytics_mcp.tools.reporting.conversions import (
     run_conversions_report,
     _run_conversions_report_description,
 )
+from analytics_mcp.tools.reporting.audience_exports import (
+    create_audience_export,
+    get_audience_export,
+    list_audience_exports,
+    query_audience_export,
+)
+from analytics_mcp.tools.measurement import (
+    validate_event,
+    send_event,
+)
 
 run_report_with_description = FunctionTool(run_report)
 run_report_with_description.description = _run_report_description()
@@ -81,6 +91,12 @@ tools = [
     run_realtime_report_with_description,
     run_funnel_report_with_description,
     run_conversions_report_with_description,
+    FunctionTool(create_audience_export),
+    FunctionTool(get_audience_export),
+    FunctionTool(list_audience_exports),
+    FunctionTool(query_audience_export),
+    FunctionTool(validate_event),
+    FunctionTool(send_event),
 ]
 
 tool_map = {t.name: t for t in tools}
@@ -149,6 +165,18 @@ for tool in mcp_tools:
             "dimensions",
             "metrics",
             "conversion_spec",
+        ]
+    elif tool.name == "create_audience_export":
+        tool.inputSchema["required"] = [
+            "property_id",
+            "audience_id",
+            "dimensions",
+        ]
+    elif tool.name in ("validate_event", "send_event"):
+        tool.inputSchema["required"] = [
+            "measurement_id",
+            "client_id",
+            "events",
         ]
 
 

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -28,10 +28,18 @@ from mcp.server.lowlevel import Server
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.mcp_tool.conversion_utils import adk_to_mcp_tool_type
 
+from analytics_mcp.tools.admin.access import run_access_report
 from analytics_mcp.tools.admin.info import (
     get_account_summaries,
+    get_data_retention_settings,
     list_google_ads_links,
     get_property_details,
+    list_audiences,
+    list_custom_dimensions,
+    list_custom_metrics,
+    list_data_streams,
+    list_key_events,
+    list_properties,
     list_property_annotations,
 )
 from analytics_mcp.tools.reporting.core import (
@@ -44,7 +52,9 @@ from analytics_mcp.tools.reporting.realtime import (
 )
 from analytics_mcp.tools.reporting.metadata import (
     get_custom_dimensions_and_metrics,
+    get_metadata,
 )
+from analytics_mcp.tools.reporting.quotas import get_property_quotas
 from analytics_mcp.tools.reporting.funnel import (
     run_funnel_report,
     _run_funnel_report_description,
@@ -111,8 +121,18 @@ tools = [
     FunctionTool(get_account_summaries),
     FunctionTool(list_google_ads_links),
     FunctionTool(get_property_details),
+    FunctionTool(get_data_retention_settings),
+    FunctionTool(list_audiences),
+    FunctionTool(list_custom_dimensions),
+    FunctionTool(list_custom_metrics),
+    FunctionTool(list_data_streams),
+    FunctionTool(list_key_events),
+    FunctionTool(list_properties),
     FunctionTool(list_property_annotations),
+    FunctionTool(run_access_report),
     FunctionTool(get_custom_dimensions_and_metrics),
+    FunctionTool(get_metadata),
+    FunctionTool(get_property_quotas),
     run_report_with_description,
     run_realtime_report_with_description,
     run_funnel_report_with_description,
@@ -204,6 +224,13 @@ for tool in mcp_tools:
         ]
     elif tool.name == "run_realtime_report":
         tool.inputSchema["required"] = ["property_id", "dimensions", "metrics"]
+    elif tool.name == "run_access_report":
+        tool.inputSchema["required"] = [
+            "entity",
+            "date_ranges",
+            "dimensions",
+            "metrics",
+        ]
     elif tool.name == "run_conversions_report":
         tool.inputSchema["required"] = [
             "property_id",

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -21,7 +21,6 @@ server.
 # MCP Server Imports
 import json
 import sys
-from json import tool
 from mcp import types as mcp_types  # Use alias to avoid conflict
 from mcp.server.lowlevel import Server
 
@@ -186,7 +185,9 @@ async def list_tools() -> list[mcp_types.Tool]:
 
 
 @app.call_tool()
-async def call_mcp_tool(name: str, arguments: dict) -> list[mcp_types.Content]:
+async def call_mcp_tool(
+    name: str, arguments: dict
+) -> list[mcp_types.Content] | mcp_types.CallToolResult:
     if name in tool_map:
         tool = tool_map[name]
         try:
@@ -204,13 +205,21 @@ async def call_mcp_tool(name: str, arguments: dict) -> list[mcp_types.Content]:
                 f"MCP Server: Error executing ADK tool '{name}': {e}",
                 file=sys.stderr,
             )
-            # Return an error message in MCP format
+            # Return an error message in MCP format. isError=True so MCP
+            # clients can detect the failure programmatically instead of
+            # treating the error text as a successful response.
             error_text = json.dumps(
                 {"error": f"Failed to execute tool '{name}': {str(e)}"}
             )
-            return [mcp_types.TextContent(type="text", text=error_text)]
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=error_text)],
+                isError=True,
+            )
 
     error_text = json.dumps(
         {"error": f"Tool '{name}' not implemented by this server."}
     )
-    return [mcp_types.TextContent(type="text", text=error_text)]
+    return mcp_types.CallToolResult(
+        content=[mcp_types.TextContent(type="text", text=error_text)],
+        isError=True,
+    )

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -63,6 +63,10 @@ from analytics_mcp.tools.measurement import (
     validate_event,
     send_event,
 )
+from analytics_mcp.tools.reporting.batch import (
+    batch_run_reports,
+    _batch_run_reports_description,
+)
 from analytics_mcp.tools.reporting.compatibility import check_compatibility
 from analytics_mcp.tools.reporting.pivot import (
     run_pivot_report,
@@ -94,7 +98,13 @@ batch_run_pivot_reports_with_description.description = (
     _batch_run_pivot_reports_description()
 )
 
+batch_run_reports_with_description = FunctionTool(batch_run_reports)
+batch_run_reports_with_description.description = (
+    _batch_run_reports_description()
+)
+
 tools = [
+    batch_run_reports_with_description,
     FunctionTool(check_compatibility),
     run_pivot_report_with_description,
     batch_run_pivot_reports_with_description,
@@ -171,6 +181,11 @@ for tool in mcp_tools:
             "date_ranges",
             "dimensions",
             "metrics",
+        ]
+    elif tool.name == "batch_run_reports":
+        tool.inputSchema["required"] = [
+            "property_id",
+            "requests",
         ]
     elif tool.name == "check_compatibility":
         tool.inputSchema["required"] = ["property_id"]

--- a/analytics_mcp/coordinator.py
+++ b/analytics_mcp/coordinator.py
@@ -63,6 +63,13 @@ from analytics_mcp.tools.measurement import (
     validate_event,
     send_event,
 )
+from analytics_mcp.tools.reporting.compatibility import check_compatibility
+from analytics_mcp.tools.reporting.pivot import (
+    run_pivot_report,
+    _run_pivot_report_description,
+    batch_run_pivot_reports,
+    _batch_run_pivot_reports_description,
+)
 
 run_report_with_description = FunctionTool(run_report)
 run_report_with_description.description = _run_report_description()
@@ -80,7 +87,17 @@ run_conversions_report_with_description.description = (
 )
 
 # Instantiate the ADK tools
+run_pivot_report_with_description = FunctionTool(run_pivot_report)
+run_pivot_report_with_description.description = _run_pivot_report_description()
+batch_run_pivot_reports_with_description = FunctionTool(batch_run_pivot_reports)
+batch_run_pivot_reports_with_description.description = (
+    _batch_run_pivot_reports_description()
+)
+
 tools = [
+    FunctionTool(check_compatibility),
+    run_pivot_report_with_description,
+    batch_run_pivot_reports_with_description,
     FunctionTool(get_account_summaries),
     FunctionTool(list_google_ads_links),
     FunctionTool(get_property_details),
@@ -154,6 +171,21 @@ for tool in mcp_tools:
             "date_ranges",
             "dimensions",
             "metrics",
+        ]
+    elif tool.name == "check_compatibility":
+        tool.inputSchema["required"] = ["property_id"]
+    elif tool.name == "run_pivot_report":
+        tool.inputSchema["required"] = [
+            "property_id",
+            "date_ranges",
+            "dimensions",
+            "metrics",
+            "pivots",
+        ]
+    elif tool.name == "batch_run_pivot_reports":
+        tool.inputSchema["required"] = [
+            "property_id",
+            "requests",
         ]
     elif tool.name == "run_realtime_report":
         tool.inputSchema["required"] = ["property_id", "dimensions", "metrics"]

--- a/analytics_mcp/tools/admin/access.py
+++ b/analytics_mcp/tools/admin/access.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for running data access reports using the Admin API."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.utils import (
+    construct_account_rn,
+    construct_property_rn,
+    proto_to_dict,
+)
+from analytics_mcp.tools.client import create_admin_api_client
+from google.analytics import admin_v1beta
+
+
+def _construct_access_report_entity(entity: int | str) -> str:
+    """Returns the entity resource name for an access report request.
+
+    Accepts a property (number or 'properties/N') or an account
+    ('accounts/N').
+    """
+    if isinstance(entity, str) and entity.strip().startswith("accounts/"):
+        return construct_account_rn(entity)
+    return construct_property_rn(entity)
+
+
+async def run_access_report(
+    entity: int | str,
+    date_ranges: List[Dict[str, str]],
+    dimensions: List[str],
+    metrics: List[str],
+    limit: int = None,
+    offset: int = None,
+    return_entity_quota: bool = False,
+) -> Dict[str, Any]:
+    """Runs a data access report showing who accessed Analytics data.
+
+    Each row describes data access events, e.g. which user accessed
+    which property, when, from where, and how many data requests were
+    made. Useful for compliance and security auditing.
+
+    Access reports use their own dimension and metric names, documented
+    at
+    https://developers.google.com/analytics/devguides/config/admin/v1/access-api-schema.
+    Common dimensions include `userEmail`, `epochTimeMicros`,
+    `accessMechanism`, and `reportType`. Common metrics include
+    `accessCount`.
+
+    Args:
+        entity: The entity to report on. Accepted formats are:
+          - A number (treated as a property ID)
+          - A string consisting of 'properties/' followed by a number
+          - A string consisting of 'accounts/' followed by a number,
+            which reports on all properties under the account
+        date_ranges: A list of date range dicts, each with `start_date`
+          and `end_date` keys. Dates are in `YYYY-MM-DD` format, or the
+          relative forms `today`, `yesterday`, and `NdaysAgo`.
+        dimensions: A list of access report dimension names.
+        metrics: A list of access report metric names.
+        limit: The maximum number of rows to return (max 100,000).
+        offset: The row count of the start row (0-indexed).
+        return_entity_quota: Whether to include the current state of
+          this property's access report quota in the response.
+    """
+    request = admin_v1beta.RunAccessReportRequest(
+        entity=_construct_access_report_entity(entity),
+        date_ranges=[admin_v1beta.AccessDateRange(dr) for dr in date_ranges],
+        dimensions=[
+            admin_v1beta.AccessDimension(dimension_name=d) for d in dimensions
+        ],
+        metrics=[admin_v1beta.AccessMetric(metric_name=m) for m in metrics],
+        return_entity_quota=return_entity_quota,
+    )
+
+    if limit:
+        request.limit = limit
+
+    if offset:
+        request.offset = offset
+
+    def _sync_call():
+        return create_admin_api_client().run_access_report(request=request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/admin/info.py
+++ b/analytics_mcp/tools/admin/info.py
@@ -18,6 +18,7 @@ import asyncio
 from typing import Any, Dict, List
 
 from analytics_mcp.tools.utils import (
+    construct_account_rn,
     construct_property_rn,
     proto_to_dict,
 )
@@ -76,6 +77,202 @@ async def get_property_details(property_id: int | str) -> Dict[str, Any]:
 
     response = await asyncio.to_thread(_sync_call)
     return proto_to_dict(response)
+
+
+async def list_properties(
+    account_id: int | str, show_deleted: bool = False
+) -> List[Dict[str, Any]]:
+    """Returns the properties under a Google Analytics account.
+
+    Returns full property objects, including display name, industry
+    category, time zone, currency code, service level, and create time.
+    Use this for deeper property discovery than `get_account_summaries`,
+    which only returns summary information.
+
+    Args:
+        account_id: The Google Analytics account ID. Accepted formats are:
+          - A number
+          - A string consisting of 'accounts/' followed by a number
+        show_deleted: Whether to include soft-deleted (i.e. "trashed")
+          properties in the results. Defaults to False.
+    """
+    request = admin_v1beta.ListPropertiesRequest(
+        filter=f"parent:{construct_account_rn(account_id)}",
+        show_deleted=show_deleted,
+    )
+
+    def _sync_call():
+        properties_pager = create_admin_api_client().list_properties(
+            request=request
+        )
+        return [proto_to_dict(prop) for prop in properties_pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_key_events(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns the key events configured for a property.
+
+    Key events (formerly known as conversion events) are the events that a
+    property has marked as most important, such as purchases or sign-ups.
+    Reports use key events to calculate conversion-related metrics.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1beta.ListKeyEventsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        key_events_pager = create_admin_api_client().list_key_events(
+            request=request
+        )
+        return [proto_to_dict(key_event) for key_event in key_events_pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_data_streams(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns the data streams configured for a property.
+
+    Data streams are the sources that send data to a property, such as a
+    web site, an Android app, or an iOS app. Each stream includes its
+    platform-specific details, e.g. the measurement ID for a web stream.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1beta.ListDataStreamsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        data_streams_pager = create_admin_api_client().list_data_streams(
+            request=request
+        )
+        return [
+            proto_to_dict(data_stream) for data_stream in data_streams_pager
+        ]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_audiences(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns the audiences defined on a property.
+
+    Audiences are segments of users, e.g. "Purchasers" or "Users who
+    visited the pricing page". Knowing what audiences exist helps when
+    interpreting audience-scoped dimensions in reports or suggesting
+    targeting strategies.
+
+    Note: this uses the alpha channel of the Admin API, which may
+    change without notice.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1alpha.ListAudiencesRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        audiences_pager = create_admin_alpha_api_client().list_audiences(
+            request=request
+        )
+        return [proto_to_dict(audience) for audience in audiences_pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def get_data_retention_settings(
+    property_id: int | str,
+) -> Dict[str, Any]:
+    """Returns the data retention settings for a property.
+
+    Shows how long event-level and user-level data is kept before being
+    automatically deleted. Useful for compliance questions and for
+    knowing how far back reports can reliably look: if retention is set
+    to TWO_MONTHS, event-scoped data older than that is unavailable in
+    explorations and some reports.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1beta.GetDataRetentionSettingsRequest(
+        name=f"{construct_property_rn(property_id)}/dataRetentionSettings"
+    )
+
+    def _sync_call():
+        client = create_admin_api_client()
+        return client.get_data_retention_settings(request=request)
+
+    response = await asyncio.to_thread(_sync_call)
+    return proto_to_dict(response)
+
+
+async def list_custom_dimensions(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns the custom dimensions defined on a property (Admin API).
+
+    Includes details that the Data API metadata endpoint doesn't return:
+    the dimension's scope (EVENT or USER), parameter name, description,
+    and whether it's excluded from ads personalization. Use the
+    `get_custom_dimensions_and_metrics` tool instead if you only need
+    the API names for building reports.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1beta.ListCustomDimensionsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        dimensions_pager = create_admin_api_client().list_custom_dimensions(
+            request=request
+        )
+        return [proto_to_dict(dimension) for dimension in dimensions_pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def list_custom_metrics(property_id: int | str) -> List[Dict[str, Any]]:
+    """Returns the custom metrics defined on a property (Admin API).
+
+    Includes details that the Data API metadata endpoint doesn't return:
+    the metric's scope, parameter name, description, measurement unit,
+    and restricted metric type. Use the
+    `get_custom_dimensions_and_metrics` tool instead if you only need
+    the API names for building reports.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = admin_v1beta.ListCustomMetricsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        metrics_pager = create_admin_api_client().list_custom_metrics(
+            request=request
+        )
+        return [proto_to_dict(metric) for metric in metrics_pager]
+
+    return await asyncio.to_thread(_sync_call)
 
 
 async def list_property_annotations(

--- a/analytics_mcp/tools/client.py
+++ b/analytics_mcp/tools/client.py
@@ -37,7 +37,7 @@ def _get_package_version_with_fallback():
     """
     try:
         return metadata.version("analytics-mcp")
-    except:
+    except Exception:
         return "unknown"
 
 

--- a/analytics_mcp/tools/measurement.py
+++ b/analytics_mcp/tools/measurement.py
@@ -1,0 +1,290 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for the Google Analytics Measurement Protocol.
+
+Unlike the other tools in this server, the Measurement Protocol is a
+plain HTTP API (not a gRPC client library) and it WRITES data: events
+sent to the collect endpoint are recorded in the property. To keep the
+server safe by default:
+
+- The API secret is only ever read from the
+  ``ANALYTICS_MCP_MP_API_SECRET`` environment variable, never from tool
+  arguments, so a model cannot supply or exfiltrate secrets.
+- ``send_event`` defaults to a dry run that only validates the payload.
+  Recording an event requires the explicit ``confirm=True`` argument,
+  and the payload must pass validation first.
+"""
+
+import asyncio
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+_MP_API_SECRET_ENV_VAR = "ANALYTICS_MCP_MP_API_SECRET"
+
+_COLLECT_URL = "https://www.google-analytics.com/mp/collect"
+_DEBUG_COLLECT_URL = "https://www.google-analytics.com/debug/mp/collect"
+
+_REQUEST_TIMEOUT_SECONDS = 10.0
+
+_MAX_EVENTS_PER_REQUEST = 25
+
+
+def _get_api_secret() -> str:
+    """Returns the Measurement Protocol API secret from the environment."""
+    api_secret = os.environ.get(_MP_API_SECRET_ENV_VAR, "").strip()
+    if not api_secret:
+        raise ValueError(
+            "No Measurement Protocol API secret is configured. Set the "
+            f"{_MP_API_SECRET_ENV_VAR} environment variable to an API "
+            "secret created under the data stream's 'Measurement "
+            "Protocol API secrets' settings in Google Analytics."
+        )
+    return api_secret
+
+
+def _build_payload(
+    client_id: str,
+    events: List[Dict[str, Any]],
+    user_id: str = None,
+    timestamp_micros: int = None,
+    user_properties: Dict[str, Any] = None,
+    non_personalized_ads: bool = False,
+) -> Dict[str, Any]:
+    """Builds and validates a Measurement Protocol request payload."""
+    if not client_id or not str(client_id).strip():
+        raise ValueError("client_id must be a non-empty string.")
+    if not isinstance(events, list) or not events:
+        raise ValueError("events must contain at least one event.")
+    if len(events) > _MAX_EVENTS_PER_REQUEST:
+        raise ValueError(
+            "events must contain at most "
+            f"{_MAX_EVENTS_PER_REQUEST} events. Got {len(events)}."
+        )
+    for i, event in enumerate(events):
+        if not isinstance(event, dict):
+            raise ValueError(f"Event {i + 1} must be a dictionary.")
+        if not event.get("name"):
+            raise ValueError(f"Event {i + 1} is missing required key 'name'.")
+
+    payload = {
+        "client_id": str(client_id),
+        "events": events,
+    }
+
+    if user_id:
+        payload["user_id"] = user_id
+
+    if timestamp_micros:
+        payload["timestamp_micros"] = timestamp_micros
+
+    if user_properties:
+        payload["user_properties"] = user_properties
+
+    if non_personalized_ads:
+        payload["non_personalized_ads"] = True
+
+    return payload
+
+
+def _post_payload(
+    url: str, measurement_id: str, payload: Dict[str, Any]
+) -> httpx.Response:
+    """Posts a payload to a Measurement Protocol endpoint."""
+    if not measurement_id or not str(measurement_id).strip():
+        raise ValueError(
+            "measurement_id must be a non-empty string, e.g. 'G-XXXXXXX'. "
+            "Use the list_data_streams tool to find a web stream's "
+            "measurement ID."
+        )
+
+    response = httpx.post(
+        url,
+        params={
+            "measurement_id": measurement_id,
+            "api_secret": _get_api_secret(),
+        },
+        json=payload,
+        timeout=_REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return response
+
+
+def _validation_messages(response: httpx.Response) -> List[Dict[str, Any]]:
+    """Extracts validation messages from a debug endpoint response."""
+    try:
+        body = response.json()
+    except ValueError:
+        return []
+    return body.get("validationMessages", [])
+
+
+async def validate_event(
+    measurement_id: str,
+    client_id: str,
+    events: List[Dict[str, Any]],
+    user_id: str = None,
+    timestamp_micros: int = None,
+    user_properties: Dict[str, Any] = None,
+    non_personalized_ads: bool = False,
+) -> Dict[str, Any]:
+    """Validates Measurement Protocol events without recording them.
+
+    Sends the events to the Measurement Protocol debug endpoint, which
+    checks the payload and returns validation messages. Nothing is
+    recorded in the property, so this is always safe to call.
+
+    Requires the ANALYTICS_MCP_MP_API_SECRET environment variable to be
+    set to a Measurement Protocol API secret for the data stream.
+
+    Args:
+        measurement_id: The web data stream's measurement ID, e.g.
+          'G-XXXXXXX'. Use the `list_data_streams` tool to find it.
+        client_id: A unique identifier for the client/user instance,
+          e.g. the GA client ID from the _ga cookie, or any stable
+          UUID-like string for server-generated events.
+        events: A list of 1 to 25 event objects. Each object must
+          contain a `name` key (e.g. 'tutorial_complete') and may
+          contain a `params` dict, per
+          https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events.
+        user_id: An optional persistent user identifier.
+        timestamp_micros: Optional Unix epoch microseconds for the
+          events. Must be within the last 72 hours.
+        user_properties: Optional user properties dict, e.g.
+          `{"plan": {"value": "premium"}}`.
+        non_personalized_ads: Whether the events should be excluded
+          from ads personalization.
+    """
+    payload = _build_payload(
+        client_id,
+        events,
+        user_id=user_id,
+        timestamp_micros=timestamp_micros,
+        user_properties=user_properties,
+        non_personalized_ads=non_personalized_ads,
+    )
+
+    def _sync_call():
+        return _post_payload(_DEBUG_COLLECT_URL, measurement_id, payload)
+
+    response = await asyncio.to_thread(_sync_call)
+    messages = _validation_messages(response)
+
+    return {
+        "valid": not messages,
+        "validation_messages": messages,
+    }
+
+
+async def send_event(
+    measurement_id: str,
+    client_id: str,
+    events: List[Dict[str, Any]],
+    user_id: str = None,
+    timestamp_micros: int = None,
+    user_properties: Dict[str, Any] = None,
+    non_personalized_ads: bool = False,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Sends Measurement Protocol events to a Google Analytics property.
+
+    WARNING: with `confirm=True` this WRITES events into the property's
+    data, which cannot be undone. By default (`confirm=False`) this
+    tool performs a dry run: the payload is validated against the
+    debug endpoint and nothing is recorded. Only pass `confirm=True`
+    after the user has explicitly approved sending the events.
+
+    Even with `confirm=True`, the payload is validated first and the
+    send is aborted if validation fails.
+
+    Requires the ANALYTICS_MCP_MP_API_SECRET environment variable to be
+    set to a Measurement Protocol API secret for the data stream.
+
+    Args:
+        measurement_id: The web data stream's measurement ID, e.g.
+          'G-XXXXXXX'. Use the `list_data_streams` tool to find it.
+        client_id: A unique identifier for the client/user instance,
+          e.g. the GA client ID from the _ga cookie, or any stable
+          UUID-like string for server-generated events.
+        events: A list of 1 to 25 event objects. Each object must
+          contain a `name` key (e.g. 'tutorial_complete') and may
+          contain a `params` dict, per
+          https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events.
+        user_id: An optional persistent user identifier.
+        timestamp_micros: Optional Unix epoch microseconds for the
+          events. Must be within the last 72 hours.
+        user_properties: Optional user properties dict, e.g.
+          `{"plan": {"value": "premium"}}`.
+        non_personalized_ads: Whether the events should be excluded
+          from ads personalization.
+        confirm: Must be True to actually record the events. When
+          False (the default), only validation is performed and a
+          dry-run result is returned.
+    """
+    validation = await validate_event(
+        measurement_id,
+        client_id,
+        events,
+        user_id=user_id,
+        timestamp_micros=timestamp_micros,
+        user_properties=user_properties,
+        non_personalized_ads=non_personalized_ads,
+    )
+
+    if not confirm:
+        return {
+            "sent": False,
+            "dry_run": True,
+            "validation": validation,
+            "message": (
+                "Dry run only — no events were recorded. To send these "
+                "events for real, call send_event again with "
+                "confirm=True after the user has approved it."
+            ),
+        }
+
+    if not validation["valid"]:
+        return {
+            "sent": False,
+            "dry_run": False,
+            "validation": validation,
+            "message": (
+                "Events were NOT sent because validation failed. Fix "
+                "the issues in validation_messages and try again."
+            ),
+        }
+
+    payload = _build_payload(
+        client_id,
+        events,
+        user_id=user_id,
+        timestamp_micros=timestamp_micros,
+        user_properties=user_properties,
+        non_personalized_ads=non_personalized_ads,
+    )
+
+    def _sync_call():
+        return _post_payload(_COLLECT_URL, measurement_id, payload)
+
+    await asyncio.to_thread(_sync_call)
+
+    return {
+        "sent": True,
+        "dry_run": False,
+        "events_sent": len(events),
+        "validation": validation,
+    }

--- a/analytics_mcp/tools/reporting/audience_exports.py
+++ b/analytics_mcp/tools/reporting/audience_exports.py
@@ -198,10 +198,10 @@ async def query_audience_export(
         name=_construct_audience_export_rn(property_id, audience_export)
     )
 
-    if offset:
+    if offset is not None:
         request.offset = offset
 
-    if limit:
+    if limit is not None:
         request.limit = limit
 
     def _sync_call():

--- a/analytics_mcp/tools/reporting/audience_exports.py
+++ b/analytics_mcp/tools/reporting/audience_exports.py
@@ -1,0 +1,212 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating and querying audience exports using the Data API."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.utils import (
+    construct_property_rn,
+    proto_to_dict,
+)
+from analytics_mcp.tools.client import create_data_api_client
+from google.analytics import data_v1beta
+
+
+def _construct_audience_export_rn(
+    property_id: int | str, audience_export: int | str
+) -> str:
+    """Returns an audience export resource name.
+
+    Args:
+        property_id: The property the export belongs to.
+        audience_export: Either a numeric audience export ID or a full
+            resource name of the form
+            'properties/{property}/audienceExports/{id}'.
+    """
+    if isinstance(audience_export, str):
+        audience_export = audience_export.strip()
+        if audience_export.startswith("properties/"):
+            return audience_export
+
+    return (
+        f"{construct_property_rn(property_id)}/"
+        f"audienceExports/{audience_export}"
+    )
+
+
+async def create_audience_export(
+    property_id: int | str,
+    audience_id: int | str,
+    dimensions: List[str],
+) -> Dict[str, Any]:
+    """Starts an asynchronous audience export job.
+
+    An audience export is a snapshot of the users in an audience at the
+    time of creation. Creating the export starts a long-running job;
+    poll its state with `get_audience_export`, and retrieve the user
+    rows with `query_audience_export` once the state is ACTIVE.
+
+    Note: although this creates an export object, the operation only
+    reads analytics data and is permitted by the analytics.readonly
+    scope. Exports are retained for about 72 hours, and creation
+    charges audience export quota tokens.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        audience_id: The audience to export. Accepted formats are:
+          - A number (the audience ID)
+          - A full resource name, e.g. 'properties/1234/audiences/5678'
+          Use the `list_audiences` tool to discover audience IDs.
+        dimensions: The dimensions to include for each user, e.g.
+          `["deviceId"]`. Valid names are listed at
+          https://developers.google.com/analytics/devguides/reporting/data/v1/audience-list-basics#dimensions.
+    """
+    property_rn = construct_property_rn(property_id)
+
+    if isinstance(audience_id, str) and audience_id.strip().startswith(
+        "properties/"
+    ):
+        audience_rn = audience_id.strip()
+    else:
+        audience_rn = f"{property_rn}/audiences/{audience_id}"
+
+    request = data_v1beta.CreateAudienceExportRequest(
+        parent=property_rn,
+        audience_export=data_v1beta.AudienceExport(
+            audience=audience_rn,
+            dimensions=[
+                data_v1beta.AudienceDimension(dimension_name=d)
+                for d in dimensions
+            ],
+        ),
+    )
+
+    def _sync_call():
+        operation = create_data_api_client().create_audience_export(
+            request=request
+        )
+        # The operation metadata is the AudienceExport being created,
+        # including its name and state. Don't block on completion;
+        # callers poll with get_audience_export.
+        return operation.metadata
+
+    metadata = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(metadata)
+
+
+async def get_audience_export(
+    property_id: int | str, audience_export: int | str
+) -> Dict[str, Any]:
+    """Returns the configuration and state of an audience export.
+
+    Use this to poll an export created with `create_audience_export`.
+    When `state` is ACTIVE, the export can be queried with
+    `query_audience_export`.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        audience_export: The audience export to look up. Accepted
+          formats are:
+          - A number (the audience export ID)
+          - A full resource name, e.g.
+            'properties/1234/audienceExports/5678'
+    """
+    request = data_v1beta.GetAudienceExportRequest(
+        name=_construct_audience_export_rn(property_id, audience_export)
+    )
+
+    def _sync_call():
+        return create_data_api_client().get_audience_export(request=request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)
+
+
+async def list_audience_exports(
+    property_id: int | str,
+) -> List[Dict[str, Any]]:
+    """Returns all audience exports for a property.
+
+    Exports are retained for about 72 hours after creation.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = data_v1beta.ListAudienceExportsRequest(
+        parent=construct_property_rn(property_id)
+    )
+
+    def _sync_call():
+        exports_pager = create_data_api_client().list_audience_exports(
+            request=request
+        )
+        return [proto_to_dict(export) for export in exports_pager]
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def query_audience_export(
+    property_id: int | str,
+    audience_export: int | str,
+    offset: int = None,
+    limit: int = None,
+) -> Dict[str, Any]:
+    """Retrieves the user rows from a completed audience export.
+
+    The export must be in the ACTIVE state; check with
+    `get_audience_export` first. Each row contains the dimension values
+    requested when the export was created.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        audience_export: The audience export to query. Accepted formats
+          are:
+          - A number (the audience export ID)
+          - A full resource name, e.g.
+            'properties/1234/audienceExports/5678'
+        offset: The row count of the start row (0-indexed).
+        limit: The maximum number of rows to return.
+    """
+    request = data_v1beta.QueryAudienceExportRequest(
+        name=_construct_audience_export_rn(property_id, audience_export)
+    )
+
+    if offset:
+        request.offset = offset
+
+    if limit:
+        request.limit = limit
+
+    def _sync_call():
+        return create_data_api_client().query_audience_export(request=request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/batch.py
+++ b/analytics_mcp/tools/reporting/batch.py
@@ -1,0 +1,221 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for running batch reports using the Data API."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.reporting.metadata import (
+    get_date_ranges_hints,
+    get_dimension_filter_hints,
+    get_metric_filter_hints,
+    get_order_bys_hints,
+)
+from analytics_mcp.tools.utils import (
+    construct_property_rn,
+    proto_to_dict,
+)
+from analytics_mcp.tools.client import create_data_api_client
+from google.analytics import data_v1beta
+
+
+def _batch_run_reports_description() -> str:
+    """Returns the description for the `batch_run_reports` tool."""
+    return f"""
+          {batch_run_reports.__doc__}
+
+          ## Hints for arguments
+
+          Here are some hints that outline the expected format and
+          requirements for arguments. Each object in the `requests`
+          list uses the same argument formats as the `run_report` tool.
+
+          ### Hints for `dimensions`
+
+          The `dimensions` list must consist solely of either of the
+          following:
+
+          1.  Standard dimensions defined in the HTML table at
+              https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions.
+              These dimensions are available to *every* property.
+          2.  Custom dimensions for the `property_id`. Use the
+              `get_custom_dimensions_and_metrics` tool to retrieve the
+              list of custom dimensions for a property.
+
+          ### Hints for `metrics`
+
+          The `metrics` list must consist solely of either of the
+          following:
+
+          1.  Standard metrics defined in the HTML table at
+              https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics.
+              These metrics are available to *every* property.
+          2.  Custom metrics for the `property_id`. Use the
+              `get_custom_dimensions_and_metrics` tool to retrieve the
+              list of custom metrics for a property.
+
+
+          ### Hints for `date_ranges`:
+          {get_date_ranges_hints()}
+
+          ### Hints for `dimension_filter`:
+          {get_dimension_filter_hints()}
+
+          ### Hints for `metric_filter`:
+          {get_metric_filter_hints()}
+
+          ### Hints for `order_bys`:
+          {get_order_bys_hints()}
+
+          """
+
+
+def _build_report_request(
+    property_rn: str, report: Dict[str, Any]
+) -> data_v1beta.RunReportRequest:
+    """Builds a RunReportRequest proto from a report specification dict.
+
+    Args:
+        property_rn: The property resource name (e.g. "properties/12345").
+        report: A dict with keys matching the `run_report` tool's
+            parameters: `dimensions`, `metrics`, `date_ranges`, and
+            optionally `dimension_filter`, `metric_filter`, `order_bys`,
+            `limit`, `offset`, `currency_code`, `return_property_quota`.
+
+    Returns:
+        A RunReportRequest proto.
+    """
+    request = data_v1beta.RunReportRequest(
+        property=property_rn,
+        dimensions=[
+            data_v1beta.Dimension(name=d) for d in report["dimensions"]
+        ],
+        metrics=[data_v1beta.Metric(name=m) for m in report["metrics"]],
+        date_ranges=[data_v1beta.DateRange(dr) for dr in report["date_ranges"]],
+        return_property_quota=report.get("return_property_quota", False),
+    )
+
+    dimension_filter = report.get("dimension_filter")
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
+        )
+
+    metric_filter = report.get("metric_filter")
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    order_bys = report.get("order_bys")
+    if order_bys:
+        request.order_bys = [data_v1beta.OrderBy(ob) for ob in order_bys]
+
+    limit = report.get("limit")
+    if limit:
+        request.limit = limit
+
+    offset = report.get("offset")
+    if offset:
+        request.offset = offset
+
+    currency_code = report.get("currency_code")
+    if currency_code:
+        request.currency_code = currency_code
+
+    return request
+
+
+async def batch_run_reports(
+    property_id: int | str,
+    requests: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Runs multiple Google Analytics Data API reports in a single request.
+
+    Use this tool instead of calling `run_report` multiple times when you
+    need data from several reports for the same property. This reduces
+    latency by combining up to 5 reports into one API call.
+
+    Each object in the `requests` list accepts the same arguments as the
+    `run_report` tool.
+
+    Note that the reference docs at
+    https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta
+    all use camelCase field names, but field names passed to this method
+    should be in snake_case since the tool is using the protocol buffers
+    (protobuf) format. The protocol buffers for the Data API are available
+    at
+    https://github.com/googleapis/googleapis/tree/master/google/analytics/data/v1beta.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        requests: A list of 1 to 5 report request objects. Each object
+          must contain the following required keys:
+          - `dimensions`: A list of dimensions to include in the report.
+          - `metrics`: A list of metrics to include in the report.
+          - `date_ranges`: A list of date ranges
+            (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/DateRange)
+            to include in the report.
+
+          Each object may also contain the following optional keys:
+          - `dimension_filter`: A Data API FilterExpression
+            (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression)
+            to apply to the dimensions.
+          - `metric_filter`: A Data API FilterExpression to apply to the
+            metrics.
+          - `order_bys`: A list of Data API OrderBy
+            (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/OrderBy)
+            objects.
+          - `limit`: The maximum number of rows to return (max 250,000).
+          - `offset`: The row count of the start row (0-indexed).
+          - `currency_code`: An ISO4217 currency code (e.g. "USD").
+          - `return_property_quota`: Whether to return property quota
+            information in the response (default: false).
+    """
+    if not isinstance(requests, list):
+        raise ValueError("requests must be a list.")
+    if not requests:
+        raise ValueError("requests must contain at least one report request.")
+    if len(requests) > 5:
+        raise ValueError(
+            "requests must contain at most 5 report requests. "
+            f"Got {len(requests)}."
+        )
+
+    for i, report in enumerate(requests):
+        if not isinstance(report, dict):
+            raise ValueError(f"Request {i + 1} must be a dictionary.")
+        for key in ("dimensions", "metrics", "date_ranges"):
+            if key not in report:
+                raise ValueError(
+                    f"Request {i + 1} is missing required key " f"'{key}'."
+                )
+            if not isinstance(report[key], list):
+                raise ValueError(f"Request {i + 1} '{key}' must be a list.")
+
+    property_rn = construct_property_rn(property_id)
+
+    batch_request = data_v1beta.BatchRunReportsRequest(
+        property=property_rn,
+        requests=[_build_report_request(property_rn, r) for r in requests],
+    )
+
+    def _sync_call():
+        return create_data_api_client().batch_run_reports(batch_request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/compatibility.py
+++ b/analytics_mcp/tools/reporting/compatibility.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for checking dimension and metric compatibility."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.utils import (
+    construct_property_rn,
+    proto_to_dict,
+)
+from analytics_mcp.tools.client import create_data_api_client
+from google.analytics import data_v1beta
+
+
+async def check_compatibility(
+    property_id: int | str,
+    dimensions: List[str] = None,
+    metrics: List[str] = None,
+    dimension_filter: Dict[str, Any] = None,
+    metric_filter: Dict[str, Any] = None,
+    compatibility_filter: str = None,
+) -> Dict[str, Any]:
+    """Checks which dimensions and metrics can be added to a report.
+
+    Use this before `run_report` when combining several dimensions and
+    metrics, to avoid wasted report requests with incompatible field
+    combinations. The check is fast and consumes minimal quota.
+
+    The response lists dimensions and metrics with their compatibility:
+    `COMPATIBLE` fields can be added to a report containing the
+    requested fields; `INCOMPATIBLE` fields cannot.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        dimensions: The dimensions already in the report, e.g.
+          `["country", "city"]`. May be empty or omitted.
+        metrics: The metrics already in the report, e.g.
+          `["activeUsers"]`. May be empty or omitted.
+        dimension_filter: A Data API FilterExpression
+          (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression)
+          applied to the dimensions in the planned report.
+        metric_filter: A Data API FilterExpression applied to the
+          metrics in the planned report.
+        compatibility_filter: Optionally restrict the response to a
+          single compatibility level. One of `"COMPATIBLE"` or
+          `"INCOMPATIBLE"`. Filtering to `"COMPATIBLE"` is recommended
+          since the full response can be large.
+    """
+    request = data_v1beta.CheckCompatibilityRequest(
+        property=construct_property_rn(property_id),
+        dimensions=[data_v1beta.Dimension(name=d) for d in (dimensions or [])],
+        metrics=[data_v1beta.Metric(name=m) for m in (metrics or [])],
+    )
+
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
+        )
+
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    if compatibility_filter:
+        try:
+            request.compatibility_filter = data_v1beta.Compatibility[
+                compatibility_filter.upper()
+            ]
+        except KeyError:
+            raise ValueError(
+                "compatibility_filter must be 'COMPATIBLE' or "
+                f"'INCOMPATIBLE'. Got '{compatibility_filter}'."
+            )
+
+    def _sync_call():
+        return create_data_api_client().check_compatibility(request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/conversions.py
+++ b/analytics_mcp/tools/reporting/conversions.py
@@ -175,11 +175,11 @@ async def run_conversions_report(
             data_v1alpha.OrderBy(order_by) for order_by in order_bys
         ]
 
-    if limit:
+    if limit is not None:
         request.limit = limit
-    if offset:
+    if offset is not None:
         request.offset = offset
-    if currency_code:
+    if currency_code is not None:
         request.currency_code = currency_code
 
     def _sync_call():

--- a/analytics_mcp/tools/reporting/core.py
+++ b/analytics_mcp/tools/reporting/core.py
@@ -161,11 +161,11 @@ async def run_report(
             data_v1beta.OrderBy(order_by) for order_by in order_bys
         ]
 
-    if limit:
+    if limit is not None:
         request.limit = limit
-    if offset:
+    if offset is not None:
         request.offset = offset
-    if currency_code:
+    if currency_code is not None:
         request.currency_code = currency_code
 
     def _sync_call():

--- a/analytics_mcp/tools/reporting/metadata.py
+++ b/analytics_mcp/tools/reporting/metadata.py
@@ -474,6 +474,36 @@ def get_order_bys_hints():
     """
 
 
+async def get_metadata(property_id: int | str) -> Dict[str, Any]:
+    """Returns the full dimension and metric catalog for a property.
+
+    Includes every dimension and metric available in reports for the
+    property — both standard and custom — with API names, display names,
+    descriptions, category groupings, and deprecation status. Use this
+    to discover what fields are available before building a report.
+
+    If you only need the property's custom definitions, use the
+    `get_custom_dimensions_and_metrics` tool instead, since its response
+    is much smaller.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+
+    # Validate the property ID before building the client: constructing the
+    # client requires credentials, so doing it first turns an invalid ID into
+    # a DefaultCredentialsError instead of the documented ValueError.
+    metadata_rn = f"{construct_property_rn(property_id)}/metadata"
+
+    def _sync_call():
+        return create_data_api_client().get_metadata(name=metadata_rn)
+
+    metadata = await asyncio.to_thread(_sync_call)
+    return proto_to_dict(metadata)
+
+
 async def get_custom_dimensions_and_metrics(
     property_id: int | str,
 ) -> Dict[str, List[Dict[str, Any]]]:
@@ -486,10 +516,13 @@ async def get_custom_dimensions_and_metrics(
 
     """
 
+    # Validate the property ID before building the client: constructing the
+    # client requires credentials, so doing it first turns an invalid ID into
+    # a DefaultCredentialsError instead of the documented ValueError.
+    metadata_rn = f"{construct_property_rn(property_id)}/metadata"
+
     def _sync_call():
-        return create_data_api_client().get_metadata(
-            name=f"{construct_property_rn(property_id)}/metadata"
-        )
+        return create_data_api_client().get_metadata(name=metadata_rn)
 
     metadata = await asyncio.to_thread(_sync_call)
     custom_metrics = [

--- a/analytics_mcp/tools/reporting/pivot.py
+++ b/analytics_mcp/tools/reporting/pivot.py
@@ -1,0 +1,358 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for running pivot reports using the Data API."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from analytics_mcp.tools.reporting.metadata import (
+    get_date_ranges_hints,
+    get_dimension_filter_hints,
+    get_metric_filter_hints,
+)
+from analytics_mcp.tools.utils import (
+    construct_property_rn,
+    proto_to_dict,
+    proto_to_json,
+)
+from analytics_mcp.tools.client import create_data_api_client
+from google.analytics import data_v1beta
+
+
+def _get_pivots_hints() -> str:
+    """Returns hints and examples for pivots arguments."""
+    pivot_country = data_v1beta.Pivot(
+        field_names=["country"],
+        limit=10,
+    )
+    pivot_device = data_v1beta.Pivot(
+        field_names=["deviceCategory"],
+        limit=5,
+        order_bys=[
+            data_v1beta.OrderBy(
+                metric=data_v1beta.OrderBy.MetricOrderBy(
+                    metric_name="activeUsers"
+                ),
+                desc=True,
+            )
+        ],
+    )
+    pivot_aggregated = data_v1beta.Pivot(
+        field_names=["eventName"],
+        limit=20,
+        metric_aggregations=["TOTAL"],
+    )
+
+    return f"""Example pivots arguments:
+
+    1.  A single pivot on 'country':
+        [ {proto_to_json(pivot_country)} ]
+
+    2.  Cross-tabulate 'country' by 'deviceCategory', ordering the
+        device columns by descending active users:
+        [
+          {proto_to_json(pivot_country)},
+          {proto_to_json(pivot_device)}
+        ]
+
+    3.  A pivot with metric aggregations (totals):
+        [ {proto_to_json(pivot_aggregated)} ]
+
+    Each pivot's `field_names` must be a subset of the report request's
+    `dimensions`. A `limit` is required in practice: the product of all
+    pivots' limits must not exceed 250,000, and each pivot's limit
+    defaults to a large value if omitted.
+    """
+
+
+def _run_pivot_report_description() -> str:
+    """Returns the description for the `run_pivot_report` tool."""
+    return f"""
+          {run_pivot_report.__doc__}
+
+          ## Hints for arguments
+
+          ### Hints for `dimensions`
+
+          The `dimensions` list must consist solely of either of the
+          following:
+
+          1.  Standard dimensions defined in the HTML table at
+              https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions.
+              These dimensions are available to *every* property.
+          2.  Custom dimensions for the `property_id`. Use the
+              `get_custom_dimensions_and_metrics` tool to retrieve the
+              list of custom dimensions for a property.
+
+          ### Hints for `metrics`
+
+          The `metrics` list must consist solely of either of the
+          following:
+
+          1.  Standard metrics defined in the HTML table at
+              https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics.
+              These metrics are available to *every* property.
+          2.  Custom metrics for the `property_id`. Use the
+              `get_custom_dimensions_and_metrics` tool to retrieve the
+              list of custom metrics for a property.
+
+          ### Hints for `pivots`:
+          {_get_pivots_hints()}
+
+          ### Hints for `date_ranges`:
+          {get_date_ranges_hints()}
+
+          ### Hints for `dimension_filter`:
+          {get_dimension_filter_hints()}
+
+          ### Hints for `metric_filter`:
+          {get_metric_filter_hints()}
+
+          """
+
+
+async def run_pivot_report(
+    property_id: int | str,
+    date_ranges: List[Dict[str, Any]],
+    dimensions: List[str],
+    metrics: List[str],
+    pivots: List[Dict[str, Any]],
+    dimension_filter: Dict[str, Any] = None,
+    metric_filter: Dict[str, Any] = None,
+    currency_code: str = None,
+    keep_empty_rows: bool = False,
+    return_property_quota: bool = False,
+) -> Dict[str, Any]:
+    """Runs a Google Analytics Data API pivot report.
+
+    Pivot reports cross-tabulate dimensions, e.g. country x device
+    category, without client-side post-processing. Use `run_report`
+    instead for flat, non-pivoted tables.
+
+    Note that the reference docs at
+    https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta
+    all use camelCase field names, but field names passed to this method
+    should be in snake_case since the tool is using the protocol buffers
+    (protobuf) format. The protocol buffers for the Data API are
+    available at
+    https://github.com/googleapis/googleapis/tree/master/google/analytics/data/v1beta.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        date_ranges: A list of date ranges
+          (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/DateRange)
+          to include in the report.
+        dimensions: A list of dimensions to include in the report. Every
+          dimension referenced by a pivot must be listed here.
+        metrics: A list of metrics to include in the report.
+        pivots: A list of Data API Pivot
+          (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runPivotReport#Pivot)
+          objects describing the visual layout of the report's
+          dimension columns and rows. Each pivot must contain
+          `field_names` (a subset of `dimensions`) and should contain a
+          `limit`. The product of all pivots' limits must not exceed
+          250,000.
+        dimension_filter: A Data API FilterExpression
+          (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression)
+          to apply to the dimensions. Must not contain metrics.
+        metric_filter: A Data API FilterExpression to apply to the
+          metrics. Must not contain dimensions.
+        currency_code: An ISO4217 currency code (e.g. "USD").
+        keep_empty_rows: Whether to include rows whose metrics are all
+          zero.
+        return_property_quota: Whether to return property quota
+          information in the response.
+    """
+    request = _build_pivot_report_request(
+        construct_property_rn(property_id),
+        {
+            "date_ranges": date_ranges,
+            "dimensions": dimensions,
+            "metrics": metrics,
+            "pivots": pivots,
+            "dimension_filter": dimension_filter,
+            "metric_filter": metric_filter,
+            "currency_code": currency_code,
+            "keep_empty_rows": keep_empty_rows,
+            "return_property_quota": return_property_quota,
+        },
+    )
+
+    def _sync_call():
+        return create_data_api_client().run_pivot_report(request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)
+
+
+def _validate_pivot_report_spec(spec: Dict[str, Any], label: str) -> None:
+    """Validates a pivot report specification dict.
+
+    Args:
+        spec: The report specification to validate.
+        label: A label identifying the spec in error messages.
+    """
+    for key in ("dimensions", "metrics", "date_ranges", "pivots"):
+        if not spec.get(key):
+            raise ValueError(f"{label} is missing required key '{key}'.")
+        if not isinstance(spec[key], list):
+            raise ValueError(f"{label} '{key}' must be a list.")
+
+    for i, pivot in enumerate(spec["pivots"]):
+        if not isinstance(pivot, dict):
+            raise ValueError(f"{label} pivot {i + 1} must be a dictionary.")
+        if not pivot.get("field_names"):
+            raise ValueError(
+                f"{label} pivot {i + 1} is missing required key "
+                "'field_names'."
+            )
+
+
+def _build_pivot_report_request(
+    property_rn: str, spec: Dict[str, Any]
+) -> data_v1beta.RunPivotReportRequest:
+    """Builds a RunPivotReportRequest proto from a specification dict.
+
+    Args:
+        property_rn: The property resource name (e.g. "properties/12345").
+        spec: A dict with keys matching the `run_pivot_report` tool's
+            parameters: `date_ranges`, `dimensions`, `metrics`,
+            `pivots`, and optionally `dimension_filter`,
+            `metric_filter`, `currency_code`, `keep_empty_rows`,
+            `return_property_quota`.
+
+    Returns:
+        A RunPivotReportRequest proto.
+    """
+    _validate_pivot_report_spec(spec, "Request")
+
+    request = data_v1beta.RunPivotReportRequest(
+        property=property_rn,
+        dimensions=[data_v1beta.Dimension(name=d) for d in spec["dimensions"]],
+        metrics=[data_v1beta.Metric(name=m) for m in spec["metrics"]],
+        date_ranges=[data_v1beta.DateRange(dr) for dr in spec["date_ranges"]],
+        pivots=[data_v1beta.Pivot(p) for p in spec["pivots"]],
+        keep_empty_rows=spec.get("keep_empty_rows", False),
+        return_property_quota=spec.get("return_property_quota", False),
+    )
+
+    dimension_filter = spec.get("dimension_filter")
+    if dimension_filter:
+        request.dimension_filter = data_v1beta.FilterExpression(
+            dimension_filter
+        )
+
+    metric_filter = spec.get("metric_filter")
+    if metric_filter:
+        request.metric_filter = data_v1beta.FilterExpression(metric_filter)
+
+    currency_code = spec.get("currency_code")
+    if currency_code:
+        request.currency_code = currency_code
+
+    return request
+
+
+def _batch_run_pivot_reports_description() -> str:
+    """Returns the description for the `batch_run_pivot_reports` tool."""
+    return f"""
+          {batch_run_pivot_reports.__doc__}
+
+          ## Hints for arguments
+
+          Each object in the `requests` list uses the same argument
+          formats as the `run_pivot_report` tool. See that tool's
+          description for hints on `dimensions`, `metrics`, `pivots`,
+          `date_ranges`, and filters.
+
+          ### Hints for `pivots` (per request):
+          {_get_pivots_hints()}
+          """
+
+
+async def batch_run_pivot_reports(
+    property_id: int | str,
+    requests: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Runs multiple Google Analytics pivot reports in a single request.
+
+    Use this tool instead of calling `run_pivot_report` multiple times
+    when you need several pivot reports for the same property. This
+    reduces latency by combining up to 5 pivot reports into one API
+    call.
+
+    Each object in the `requests` list accepts the same arguments as
+    the `run_pivot_report` tool.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats
+          are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+        requests: A list of 1 to 5 pivot report request objects. Each
+          object must contain the following required keys:
+          - `date_ranges`: A list of date ranges to include.
+          - `dimensions`: A list of dimensions to include.
+          - `metrics`: A list of metrics to include.
+          - `pivots`: A list of Pivot objects, each with `field_names`
+            (a subset of the request's `dimensions`) and a `limit`.
+
+          Each object may also contain the following optional keys:
+          - `dimension_filter`: A Data API FilterExpression to apply to
+            the dimensions.
+          - `metric_filter`: A Data API FilterExpression to apply to
+            the metrics.
+          - `currency_code`: An ISO4217 currency code (e.g. "USD").
+          - `keep_empty_rows`: Whether to include rows whose metrics
+            are all zero.
+          - `return_property_quota`: Whether to return property quota
+            information in the response.
+    """
+    if not isinstance(requests, list):
+        raise ValueError("requests must be a list.")
+    if not requests:
+        raise ValueError(
+            "requests must contain at least one pivot report request."
+        )
+    if len(requests) > 5:
+        raise ValueError(
+            "requests must contain at most 5 pivot report requests. "
+            f"Got {len(requests)}."
+        )
+
+    for i, spec in enumerate(requests):
+        if not isinstance(spec, dict):
+            raise ValueError(f"Request {i + 1} must be a dictionary.")
+        _validate_pivot_report_spec(spec, f"Request {i + 1}")
+
+    property_rn = construct_property_rn(property_id)
+
+    batch_request = data_v1beta.BatchRunPivotReportsRequest(
+        property=property_rn,
+        requests=[
+            _build_pivot_report_request(property_rn, spec) for spec in requests
+        ],
+    )
+
+    def _sync_call():
+        return create_data_api_client().batch_run_pivot_reports(batch_request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/quotas.py
+++ b/analytics_mcp/tools/reporting/quotas.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for inspecting Data API quota usage."""
+
+import asyncio
+from typing import Any, Dict
+
+from analytics_mcp.tools.utils import (
+    construct_property_rn,
+    proto_to_dict,
+)
+from analytics_mcp.tools.client import create_data_api_alpha_client
+from google.analytics import data_v1alpha
+
+
+async def get_property_quotas(property_id: int | str) -> Dict[str, Any]:
+    """Returns the current Data API quota usage for a property.
+
+    Shows consumed and remaining quota for core tokens (per day and per
+    hour), realtime tokens, funnel tokens, concurrent requests, and
+    server errors. Check this before running expensive report batches
+    so you can back off instead of hitting quota errors.
+
+    Note: this uses the alpha channel of the Data API, which may change
+    without notice.
+
+    Args:
+        property_id: The Google Analytics property ID. Accepted formats are:
+          - A number
+          - A string consisting of 'properties/' followed by a number
+    """
+    request = data_v1alpha.GetPropertyQuotasSnapshotRequest(
+        name=f"{construct_property_rn(property_id)}/propertyQuotasSnapshot"
+    )
+
+    def _sync_call():
+        client = create_data_api_alpha_client()
+        return client.get_property_quotas_snapshot(request=request)
+
+    response = await asyncio.to_thread(_sync_call)
+
+    return proto_to_dict(response)

--- a/analytics_mcp/tools/reporting/realtime.py
+++ b/analytics_mcp/tools/reporting/realtime.py
@@ -153,9 +153,9 @@ async def run_realtime_report(
             data_v1beta.OrderBy(order_by) for order_by in order_bys
         ]
 
-    if limit:
+    if limit is not None:
         request.limit = limit
-    if offset:
+    if offset is not None:
         request.offset = offset
 
     def _sync_call():

--- a/analytics_mcp/tools/utils.py
+++ b/analytics_mcp/tools/utils.py
@@ -44,6 +44,31 @@ def construct_property_rn(property_value: int | str) -> str:
     return f"properties/{property_num}"
 
 
+def construct_account_rn(account_value: int | str) -> str:
+    """Returns an account resource name in the format required by APIs."""
+    account_num = None
+    if isinstance(account_value, int):
+        account_num = account_value
+    elif isinstance(account_value, str):
+        account_value = account_value.strip()
+        if account_value.isdigit():
+            account_num = int(account_value)
+        elif account_value.startswith("accounts/"):
+            numeric_part = account_value.split("/")[-1]
+            if numeric_part.isdigit():
+                account_num = int(numeric_part)
+    if account_num is None:
+        raise ValueError(
+            (
+                f"Invalid account ID: {account_value}. "
+                "A valid account value is either a number or a string starting "
+                "with 'accounts/' and followed by a number."
+            )
+        )
+
+    return f"accounts/{account_num}"
+
+
 def proto_to_dict(obj: proto.Message) -> Dict[str, Any]:
     """Converts a proto message to a dictionary."""
     return type(obj).to_dict(

--- a/tests/access_test.py
+++ b/tests/access_test.py
@@ -1,0 +1,137 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the run_access_report tool."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import admin_v1beta
+
+from analytics_mcp.tools.admin.access import (
+    _construct_access_report_entity,
+    run_access_report,
+)
+
+
+class TestConstructAccessReportEntity(unittest.TestCase):
+    """Test cases for _construct_access_report_entity."""
+
+    def test_property_forms(self):
+        """Tests property ID forms resolve to a property entity."""
+        self.assertEqual(
+            _construct_access_report_entity(12345), "properties/12345"
+        )
+        self.assertEqual(
+            _construct_access_report_entity("properties/12345"),
+            "properties/12345",
+        )
+
+    def test_account_form(self):
+        """Tests an 'accounts/' string resolves to an account entity."""
+        self.assertEqual(
+            _construct_access_report_entity("accounts/678"), "accounts/678"
+        )
+
+    def test_invalid_entity_raises(self):
+        """Tests that invalid entities raise a ValueError."""
+        with self.assertRaises(ValueError):
+            _construct_access_report_entity("bogus")
+        with self.assertRaises(ValueError):
+            _construct_access_report_entity("accounts/abc")
+
+
+class TestRunAccessReport(unittest.TestCase):
+    """Test cases for run_access_report."""
+
+    @patch("analytics_mcp.tools.admin.access.create_admin_api_client")
+    def test_builds_request(self, mock_create_client):
+        """Tests that the request proto is built correctly."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_access_report.return_value = (
+            admin_v1beta.RunAccessReportResponse(row_count=0)
+        )
+
+        asyncio.run(
+            run_access_report(
+                12345,
+                date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+                dimensions=["userEmail", "accessMechanism"],
+                metrics=["accessCount"],
+                limit=50,
+            )
+        )
+
+        request = mock_client.run_access_report.call_args.kwargs["request"]
+        self.assertEqual(request.entity, "properties/12345")
+        self.assertEqual(len(request.date_ranges), 1)
+        self.assertEqual(request.date_ranges[0].start_date, "7daysAgo")
+        self.assertEqual(
+            [d.dimension_name for d in request.dimensions],
+            ["userEmail", "accessMechanism"],
+        )
+        self.assertEqual(
+            [m.metric_name for m in request.metrics], ["accessCount"]
+        )
+        self.assertEqual(request.limit, 50)
+        self.assertFalse(request.return_entity_quota)
+
+    @patch("analytics_mcp.tools.admin.access.create_admin_api_client")
+    def test_account_level_report(self, mock_create_client):
+        """Tests that account-level entities are passed through."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_access_report.return_value = (
+            admin_v1beta.RunAccessReportResponse()
+        )
+
+        asyncio.run(
+            run_access_report(
+                "accounts/99",
+                date_ranges=[
+                    {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+                ],
+                dimensions=["userEmail"],
+                metrics=["accessCount"],
+            )
+        )
+
+        request = mock_client.run_access_report.call_args.kwargs["request"]
+        self.assertEqual(request.entity, "accounts/99")
+
+    @patch("analytics_mcp.tools.admin.access.create_admin_api_client")
+    def test_converts_response(self, mock_create_client):
+        """Tests that the proto response is converted to a dict."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_access_report.return_value = (
+            admin_v1beta.RunAccessReportResponse(row_count=2)
+        )
+
+        result = asyncio.run(
+            run_access_report(
+                12345,
+                date_ranges=[{"start_date": "yesterday", "end_date": "today"}],
+                dimensions=["userEmail"],
+                metrics=["accessCount"],
+            )
+        )
+
+        self.assertEqual(result["row_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/audience_exports_test.py
+++ b/tests/audience_exports_test.py
@@ -1,0 +1,192 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the audience export tools."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1beta
+
+from analytics_mcp.tools.reporting.audience_exports import (
+    _construct_audience_export_rn,
+    create_audience_export,
+    get_audience_export,
+    list_audience_exports,
+    query_audience_export,
+)
+
+_CLIENT_PATH = (
+    "analytics_mcp.tools.reporting.audience_exports.create_data_api_client"
+)
+
+
+class TestConstructAudienceExportRn(unittest.TestCase):
+    """Test cases for _construct_audience_export_rn."""
+
+    def test_numeric_id(self):
+        self.assertEqual(
+            _construct_audience_export_rn(12345, 678),
+            "properties/12345/audienceExports/678",
+        )
+
+    def test_full_resource_name_passthrough(self):
+        self.assertEqual(
+            _construct_audience_export_rn(
+                12345, "properties/999/audienceExports/1"
+            ),
+            "properties/999/audienceExports/1",
+        )
+
+    def test_invalid_property_raises(self):
+        with self.assertRaises(ValueError):
+            _construct_audience_export_rn("bogus", 678)
+
+
+class TestCreateAudienceExport(unittest.TestCase):
+    """Test cases for create_audience_export."""
+
+    @patch(_CLIENT_PATH)
+    def test_builds_request_and_returns_metadata(self, mock_create_client):
+        """Tests request construction and metadata passthrough."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_operation = MagicMock()
+        mock_operation.metadata = data_v1beta.AudienceExport(
+            name="properties/12345/audienceExports/42",
+            audience="properties/12345/audiences/777",
+            state=data_v1beta.AudienceExport.State.CREATING,
+        )
+        mock_client.create_audience_export.return_value = mock_operation
+
+        result = asyncio.run(
+            create_audience_export(12345, 777, dimensions=["deviceId"])
+        )
+
+        request = mock_client.create_audience_export.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(
+            request.audience_export.audience,
+            "properties/12345/audiences/777",
+        )
+        self.assertEqual(
+            [d.dimension_name for d in request.audience_export.dimensions],
+            ["deviceId"],
+        )
+        self.assertEqual(result["name"], "properties/12345/audienceExports/42")
+        self.assertEqual(result["state"], "CREATING")
+
+    @patch(_CLIENT_PATH)
+    def test_accepts_full_audience_rn(self, mock_create_client):
+        """Tests that a full audience resource name is passed through."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_operation = MagicMock()
+        mock_operation.metadata = data_v1beta.AudienceExport()
+        mock_client.create_audience_export.return_value = mock_operation
+
+        asyncio.run(
+            create_audience_export(
+                12345,
+                "properties/12345/audiences/888",
+                dimensions=["deviceId"],
+            )
+        )
+
+        request = mock_client.create_audience_export.call_args.kwargs["request"]
+        self.assertEqual(
+            request.audience_export.audience,
+            "properties/12345/audiences/888",
+        )
+
+
+class TestGetAudienceExport(unittest.TestCase):
+    """Test cases for get_audience_export."""
+
+    @patch(_CLIENT_PATH)
+    def test_returns_export_state(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.get_audience_export.return_value = (
+            data_v1beta.AudienceExport(
+                name="properties/12345/audienceExports/42",
+                state=data_v1beta.AudienceExport.State.ACTIVE,
+                row_count=100,
+            )
+        )
+
+        result = asyncio.run(get_audience_export(12345, 42))
+
+        request = mock_client.get_audience_export.call_args.kwargs["request"]
+        self.assertEqual(request.name, "properties/12345/audienceExports/42")
+        self.assertEqual(result["state"], "ACTIVE")
+        self.assertEqual(result["row_count"], 100)
+
+
+class TestListAudienceExports(unittest.TestCase):
+    """Test cases for list_audience_exports."""
+
+    @patch(_CLIENT_PATH)
+    def test_lists_exports(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.list_audience_exports.return_value = [
+            data_v1beta.AudienceExport(
+                name="properties/12345/audienceExports/1"
+            )
+        ]
+
+        result = asyncio.run(list_audience_exports(12345))
+
+        request = mock_client.list_audience_exports.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+
+
+class TestQueryAudienceExport(unittest.TestCase):
+    """Test cases for query_audience_export."""
+
+    @patch(_CLIENT_PATH)
+    def test_queries_rows(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.query_audience_export.return_value = (
+            data_v1beta.QueryAudienceExportResponse(
+                audience_rows=[
+                    data_v1beta.AudienceRow(
+                        dimension_values=[
+                            data_v1beta.AudienceDimensionValue(
+                                value="device-abc"
+                            )
+                        ]
+                    )
+                ],
+                row_count=1,
+            )
+        )
+
+        result = asyncio.run(query_audience_export(12345, 42, limit=10))
+
+        request = mock_client.query_audience_export.call_args.kwargs["request"]
+        self.assertEqual(request.name, "properties/12345/audienceExports/42")
+        self.assertEqual(request.limit, 10)
+        self.assertEqual(
+            result["audience_rows"][0]["dimension_values"][0]["value"],
+            "device-abc",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -1,0 +1,340 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the batch_run_reports tool."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1beta
+
+from analytics_mcp.tools.reporting.batch import (
+    batch_run_reports,
+    _build_report_request,
+)
+
+
+class TestBuildReportRequest(unittest.TestCase):
+    """Test cases for _build_report_request."""
+
+    def test_required_fields(self):
+        """Tests that required fields are set correctly."""
+        report = {
+            "dimensions": ["country", "city"],
+            "metrics": ["activeUsers", "sessions"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertIsInstance(request, data_v1beta.RunReportRequest)
+        self.assertEqual(request.property, "properties/12345")
+        self.assertEqual(len(request.dimensions), 2)
+        self.assertEqual(request.dimensions[0].name, "country")
+        self.assertEqual(request.dimensions[1].name, "city")
+        self.assertEqual(len(request.metrics), 2)
+        self.assertEqual(request.metrics[0].name, "activeUsers")
+        self.assertEqual(request.metrics[1].name, "sessions")
+        self.assertEqual(len(request.date_ranges), 1)
+        self.assertFalse(request.return_property_quota)
+
+    def test_optional_fields(self):
+        """Tests that optional fields are set when provided."""
+        report = {
+            "dimensions": ["country"],
+            "metrics": ["activeUsers"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+            "limit": 100,
+            "offset": 50,
+            "currency_code": "USD",
+            "return_property_quota": True,
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertEqual(request.limit, 100)
+        self.assertEqual(request.offset, 50)
+        self.assertEqual(request.currency_code, "USD")
+        self.assertTrue(request.return_property_quota)
+
+    def test_dimension_filter(self):
+        """Tests that dimension_filter is set when provided."""
+        report = {
+            "dimensions": ["country"],
+            "metrics": ["activeUsers"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+            "dimension_filter": {
+                "filter": {
+                    "field_name": "country",
+                    "string_filter": {
+                        "match_type": "EXACT",
+                        "value": "US",
+                    },
+                }
+            },
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertIsNotNone(request.dimension_filter)
+
+    def test_metric_filter(self):
+        """Tests that metric_filter is set when provided."""
+        report = {
+            "dimensions": ["country"],
+            "metrics": ["activeUsers"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+            "metric_filter": {
+                "filter": {
+                    "field_name": "activeUsers",
+                    "numeric_filter": {
+                        "operation": "GREATER_THAN",
+                        "value": {"int64_value": 10},
+                    },
+                }
+            },
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertIsNotNone(request.metric_filter)
+
+    def test_order_bys(self):
+        """Tests that order_bys are set when provided."""
+        report = {
+            "dimensions": ["country"],
+            "metrics": ["activeUsers"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+            "order_bys": [
+                {
+                    "metric": {
+                        "metric_name": "activeUsers",
+                    },
+                    "desc": True,
+                }
+            ],
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertEqual(len(request.order_bys), 1)
+
+    def test_optional_fields_absent(self):
+        """Tests that optional fields are absent when not provided."""
+        report = {
+            "dimensions": ["country"],
+            "metrics": ["activeUsers"],
+            "date_ranges": [
+                {
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-31",
+                }
+            ],
+        }
+        request = _build_report_request("properties/12345", report)
+
+        self.assertEqual(request.limit, 0)
+        self.assertEqual(request.offset, 0)
+        self.assertEqual(request.currency_code, "")
+        self.assertEqual(len(request.order_bys), 0)
+
+
+class TestBatchRunReports(unittest.TestCase):
+    """Test cases for batch_run_reports validation."""
+
+    def test_empty_requests_raises(self):
+        """Tests that an empty requests list raises ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, []))
+
+    def test_too_many_requests_raises(self):
+        """Tests that more than 5 requests raises ValueError."""
+        reports = [
+            {
+                "dimensions": ["country"],
+                "metrics": ["activeUsers"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    }
+                ],
+            }
+        ] * 6
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, reports))
+
+    def test_requests_not_a_list_raises(self):
+        """Tests that a non-list requests value raises ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(
+                batch_run_reports(
+                    12345,
+                    {
+                        "dimensions": ["country"],
+                        "metrics": ["activeUsers"],
+                        "date_ranges": [
+                            {
+                                "start_date": "2025-01-01",
+                                "end_date": "2025-01-31",
+                            }
+                        ],
+                    },
+                )
+            )
+
+    def test_non_dict_request_raises(self):
+        """Tests that a non-dict request raises ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, ["not a dict"]))
+
+    def test_dimensions_not_a_list_raises(self):
+        """Tests that a non-list dimensions value raises ValueError."""
+        reports = [
+            {
+                "dimensions": "country",
+                "metrics": ["activeUsers"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    }
+                ],
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, reports))
+
+    def test_missing_dimensions_raises(self):
+        """Tests that a request missing dimensions raises ValueError."""
+        reports = [
+            {
+                "metrics": ["activeUsers"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    }
+                ],
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, reports))
+
+    def test_missing_metrics_raises(self):
+        """Tests that a request missing metrics raises ValueError."""
+        reports = [
+            {
+                "dimensions": ["country"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    }
+                ],
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, reports))
+
+    def test_missing_date_ranges_raises(self):
+        """Tests that a request missing date_ranges raises ValueError."""
+        reports = [
+            {
+                "dimensions": ["country"],
+                "metrics": ["activeUsers"],
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_reports(12345, reports))
+
+    @patch("analytics_mcp.tools.reporting.batch." "create_data_api_client")
+    def test_api_called_with_correct_request(self, mock_client):
+        """Tests that the API is called with the correct request."""
+        mock_response = MagicMock()
+        mock_response.__class__ = data_v1beta.BatchRunReportsResponse
+        mock_client_instance = MagicMock()
+        mock_client_instance.batch_run_reports.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        reports = [
+            {
+                "dimensions": ["country"],
+                "metrics": ["activeUsers"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    }
+                ],
+            },
+            {
+                "dimensions": ["city"],
+                "metrics": ["sessions"],
+                "date_ranges": [
+                    {
+                        "start_date": "2025-02-01",
+                        "end_date": "2025-02-28",
+                    }
+                ],
+            },
+        ]
+
+        with patch(
+            "analytics_mcp.tools.reporting.batch.proto_to_dict",
+            return_value={"reports": []},
+        ):
+            result = asyncio.run(batch_run_reports(12345, reports))
+
+        mock_client_instance.batch_run_reports.assert_called_once()
+        call_args = mock_client_instance.batch_run_reports.call_args
+        batch_request = call_args[0][0]
+
+        self.assertEqual(batch_request.property, "properties/12345")
+        self.assertEqual(len(batch_request.requests), 2)
+        self.assertEqual(
+            batch_request.requests[0].dimensions[0].name,
+            "country",
+        )
+        self.assertEqual(
+            batch_request.requests[1].dimensions[0].name,
+            "city",
+        )
+        self.assertEqual(result, {"reports": []})

--- a/tests/compatibility_test.py
+++ b/tests/compatibility_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the check_compatibility tool."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1beta
+
+from analytics_mcp.tools.reporting.compatibility import check_compatibility
+
+
+class TestCheckCompatibility(unittest.TestCase):
+    """Test cases for check_compatibility."""
+
+    @patch("analytics_mcp.tools.reporting.compatibility.create_data_api_client")
+    def test_builds_request(self, mock_create_client):
+        """Tests that the request proto is built correctly."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.check_compatibility.return_value = (
+            data_v1beta.CheckCompatibilityResponse()
+        )
+
+        asyncio.run(
+            check_compatibility(
+                12345,
+                dimensions=["country", "city"],
+                metrics=["activeUsers"],
+            )
+        )
+
+        request = mock_client.check_compatibility.call_args.args[0]
+        self.assertEqual(request.property, "properties/12345")
+        self.assertEqual(
+            [d.name for d in request.dimensions], ["country", "city"]
+        )
+        self.assertEqual([m.name for m in request.metrics], ["activeUsers"])
+
+    @patch("analytics_mcp.tools.reporting.compatibility.create_data_api_client")
+    def test_compatibility_filter(self, mock_create_client):
+        """Tests that the compatibility filter enum is resolved."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.check_compatibility.return_value = (
+            data_v1beta.CheckCompatibilityResponse()
+        )
+
+        asyncio.run(
+            check_compatibility(
+                12345,
+                dimensions=["country"],
+                compatibility_filter="compatible",
+            )
+        )
+
+        request = mock_client.check_compatibility.call_args.args[0]
+        self.assertEqual(
+            request.compatibility_filter,
+            data_v1beta.Compatibility.COMPATIBLE,
+        )
+
+    def test_invalid_compatibility_filter_raises(self):
+        """Tests that an invalid compatibility filter raises."""
+        with self.assertRaises(ValueError):
+            asyncio.run(
+                check_compatibility(12345, compatibility_filter="bogus")
+            )
+
+    @patch("analytics_mcp.tools.reporting.compatibility.create_data_api_client")
+    def test_converts_response(self, mock_create_client):
+        """Tests that the proto response is converted to a dict."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.check_compatibility.return_value = (
+            data_v1beta.CheckCompatibilityResponse(
+                dimension_compatibilities=[
+                    data_v1beta.DimensionCompatibility(
+                        dimension_metadata=data_v1beta.DimensionMetadata(
+                            api_name="country"
+                        ),
+                        compatibility=(data_v1beta.Compatibility.COMPATIBLE),
+                    )
+                ]
+            )
+        )
+
+        result = asyncio.run(check_compatibility(12345))
+
+        self.assertEqual(
+            result["dimension_compatibilities"][0]["compatibility"],
+            "COMPATIBLE",
+        )
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(check_compatibility("bogus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/info_test.py
+++ b/tests/info_test.py
@@ -1,0 +1,283 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the admin info tools."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import admin_v1alpha, admin_v1beta
+
+from analytics_mcp.tools.admin.info import (
+    get_data_retention_settings,
+    list_audiences,
+    list_custom_dimensions,
+    list_custom_metrics,
+    list_data_streams,
+    list_key_events,
+    list_properties,
+)
+
+
+class TestListKeyEvents(unittest.TestCase):
+    """Test cases for list_key_events."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_key_events(self, mock_create_client):
+        """Tests that key events are listed and converted to dicts."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        key_event = admin_v1beta.KeyEvent(
+            name="properties/12345/keyEvents/67890",
+            event_name="purchase",
+            counting_method=(
+                admin_v1beta.KeyEvent.CountingMethod.ONCE_PER_EVENT
+            ),
+        )
+        mock_client.list_key_events.return_value = [key_event]
+
+        result = asyncio.run(list_key_events(12345))
+
+        request = mock_client.list_key_events.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["event_name"], "purchase")
+        self.assertEqual(result[0]["name"], "properties/12345/keyEvents/67890")
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_accepts_property_rn_string(self, mock_create_client):
+        """Tests that a 'properties/' prefixed string is accepted."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.list_key_events.return_value = []
+
+        result = asyncio.run(list_key_events("properties/9876"))
+
+        request = mock_client.list_key_events.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/9876")
+        self.assertEqual(result, [])
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_key_events("not-a-property"))
+
+
+class TestListDataStreams(unittest.TestCase):
+    """Test cases for list_data_streams."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_data_streams(self, mock_create_client):
+        """Tests that data streams are listed and converted to dicts."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        web_stream = admin_v1beta.DataStream(
+            name="properties/12345/dataStreams/111",
+            type_=admin_v1beta.DataStream.DataStreamType.WEB_DATA_STREAM,
+            display_name="Web stream",
+            web_stream_data=admin_v1beta.DataStream.WebStreamData(
+                measurement_id="G-ABC123",
+                default_uri="https://www.example.com",
+            ),
+        )
+        mock_client.list_data_streams.return_value = [web_stream]
+
+        result = asyncio.run(list_data_streams(12345))
+
+        request = mock_client.list_data_streams.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["display_name"], "Web stream")
+        self.assertEqual(
+            result[0]["web_stream_data"]["measurement_id"], "G-ABC123"
+        )
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_data_streams("bogus"))
+
+
+class TestListProperties(unittest.TestCase):
+    """Test cases for list_properties."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_properties(self, mock_create_client):
+        """Tests that properties are listed with an account filter."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        prop = admin_v1beta.Property(
+            name="properties/12345",
+            display_name="My property",
+            time_zone="America/New_York",
+            currency_code="USD",
+        )
+        mock_client.list_properties.return_value = [prop]
+
+        result = asyncio.run(list_properties(98765))
+
+        request = mock_client.list_properties.call_args.kwargs["request"]
+        self.assertEqual(request.filter, "parent:accounts/98765")
+        self.assertFalse(request.show_deleted)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["display_name"], "My property")
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_show_deleted_passthrough(self, mock_create_client):
+        """Tests that show_deleted is passed through to the request."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.list_properties.return_value = []
+
+        asyncio.run(list_properties("accounts/55", show_deleted=True))
+
+        request = mock_client.list_properties.call_args.kwargs["request"]
+        self.assertEqual(request.filter, "parent:accounts/55")
+        self.assertTrue(request.show_deleted)
+
+    def test_invalid_account_id_raises(self):
+        """Tests that an invalid account ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_properties("properties/123"))
+
+
+class TestListCustomDimensions(unittest.TestCase):
+    """Test cases for list_custom_dimensions."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_custom_dimensions(self, mock_create_client):
+        """Tests that custom dimensions include Admin API detail."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        dimension = admin_v1beta.CustomDimension(
+            name="properties/12345/customDimensions/1",
+            parameter_name="plan_type",
+            display_name="Plan type",
+            description="The subscription plan type.",
+            scope=admin_v1beta.CustomDimension.DimensionScope.EVENT,
+        )
+        mock_client.list_custom_dimensions.return_value = [dimension]
+
+        result = asyncio.run(list_custom_dimensions(12345))
+
+        request = mock_client.list_custom_dimensions.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["parameter_name"], "plan_type")
+        self.assertEqual(result[0]["scope"], "EVENT")
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_custom_dimensions("bogus"))
+
+
+class TestListCustomMetrics(unittest.TestCase):
+    """Test cases for list_custom_metrics."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_custom_metrics(self, mock_create_client):
+        """Tests that custom metrics include Admin API detail."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        metric = admin_v1beta.CustomMetric(
+            name="properties/12345/customMetrics/1",
+            parameter_name="loyalty_points",
+            display_name="Loyalty points",
+            measurement_unit=(
+                admin_v1beta.CustomMetric.MeasurementUnit.STANDARD
+            ),
+            scope=admin_v1beta.CustomMetric.MetricScope.EVENT,
+        )
+        mock_client.list_custom_metrics.return_value = [metric]
+
+        result = asyncio.run(list_custom_metrics(12345))
+
+        request = mock_client.list_custom_metrics.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["parameter_name"], "loyalty_points")
+        self.assertEqual(result[0]["measurement_unit"], "STANDARD")
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_custom_metrics("bogus"))
+
+
+class TestGetDataRetentionSettings(unittest.TestCase):
+    """Test cases for get_data_retention_settings."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_api_client")
+    def test_returns_settings(self, mock_create_client):
+        """Tests that retention settings are fetched and converted."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        settings = admin_v1beta.DataRetentionSettings(
+            name="properties/12345/dataRetentionSettings",
+            event_data_retention=(
+                admin_v1beta.DataRetentionSettings.RetentionDuration.FOURTEEN_MONTHS
+            ),
+            reset_user_data_on_new_activity=True,
+        )
+        mock_client.get_data_retention_settings.return_value = settings
+
+        result = asyncio.run(get_data_retention_settings(12345))
+
+        request = mock_client.get_data_retention_settings.call_args.kwargs[
+            "request"
+        ]
+        self.assertEqual(request.name, "properties/12345/dataRetentionSettings")
+        self.assertEqual(result["event_data_retention"], "FOURTEEN_MONTHS")
+        self.assertTrue(result["reset_user_data_on_new_activity"])
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(get_data_retention_settings("bogus"))
+
+
+class TestListAudiences(unittest.TestCase):
+    """Test cases for list_audiences."""
+
+    @patch("analytics_mcp.tools.admin.info.create_admin_alpha_api_client")
+    def test_returns_audiences(self, mock_create_client):
+        """Tests that audiences are listed via the alpha client."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        audience = admin_v1alpha.Audience(
+            name="properties/12345/audiences/777",
+            display_name="Purchasers",
+            description="Users who purchased.",
+            membership_duration_days=30,
+        )
+        mock_client.list_audiences.return_value = [audience]
+
+        result = asyncio.run(list_audiences(12345))
+
+        request = mock_client.list_audiences.call_args.kwargs["request"]
+        self.assertEqual(request.parent, "properties/12345")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["display_name"], "Purchasers")
+        self.assertEqual(result[0]["membership_duration_days"], 30)
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(list_audiences("bogus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/measurement_test.py
+++ b/tests/measurement_test.py
@@ -1,0 +1,181 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the Measurement Protocol tools."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from analytics_mcp.tools import measurement
+from analytics_mcp.tools.measurement import send_event, validate_event
+
+_SECRET_ENV = {"ANALYTICS_MCP_MP_API_SECRET": "test-secret"}
+
+_EVENTS = [{"name": "tutorial_complete", "params": {"step": 5}}]
+
+
+def _mock_response(validation_messages=None):
+    """Returns a mock httpx response."""
+    response = MagicMock()
+    response.json.return_value = (
+        {"validationMessages": validation_messages}
+        if validation_messages is not None
+        else {}
+    )
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestValidateEvent(unittest.TestCase):
+    """Test cases for validate_event."""
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_posts_to_debug_endpoint(self, mock_post):
+        """Tests that validation hits only the debug endpoint."""
+        mock_post.return_value = _mock_response(validation_messages=[])
+
+        result = asyncio.run(validate_event("G-TEST123", "client-1", _EVENTS))
+
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["validation_messages"], [])
+        self.assertEqual(mock_post.call_count, 1)
+        url = mock_post.call_args.args[0]
+        self.assertEqual(url, measurement._DEBUG_COLLECT_URL)
+        params = mock_post.call_args.kwargs["params"]
+        self.assertEqual(params["measurement_id"], "G-TEST123")
+        self.assertEqual(params["api_secret"], "test-secret")
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["client_id"], "client-1")
+        self.assertEqual(payload["events"], _EVENTS)
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_reports_validation_messages(self, mock_post):
+        """Tests that validation messages are surfaced."""
+        messages = [{"description": "bad event name"}]
+        mock_post.return_value = _mock_response(validation_messages=messages)
+
+        result = asyncio.run(validate_event("G-TEST123", "client-1", _EVENTS))
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["validation_messages"], messages)
+
+    @patch.dict("os.environ", {"ANALYTICS_MCP_MP_API_SECRET": ""})
+    def test_missing_secret_raises(self):
+        """Tests that a missing API secret raises a clear error."""
+        with self.assertRaises(ValueError) as ctx:
+            asyncio.run(validate_event("G-TEST123", "client-1", _EVENTS))
+        self.assertIn("ANALYTICS_MCP_MP_API_SECRET", str(ctx.exception))
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    def test_too_many_events_raises(self):
+        """Tests that more than 25 events raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(
+                validate_event("G-TEST123", "client-1", [{"name": "e"}] * 26)
+            )
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    def test_event_without_name_raises(self):
+        """Tests that an event without a name raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(
+                validate_event("G-TEST123", "client-1", [{"params": {}}])
+            )
+
+
+class TestSendEvent(unittest.TestCase):
+    """Test cases for send_event."""
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_dry_run_by_default(self, mock_post):
+        """Tests that without confirm=True nothing is recorded."""
+        mock_post.return_value = _mock_response(validation_messages=[])
+
+        result = asyncio.run(send_event("G-TEST123", "client-1", _EVENTS))
+
+        self.assertFalse(result["sent"])
+        self.assertTrue(result["dry_run"])
+        self.assertTrue(result["validation"]["valid"])
+        # Only the debug endpoint may be called on a dry run.
+        urls = [call.args[0] for call in mock_post.call_args_list]
+        self.assertEqual(urls, [measurement._DEBUG_COLLECT_URL])
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_confirm_sends_after_validation(self, mock_post):
+        """Tests that confirm=True validates then sends."""
+        mock_post.return_value = _mock_response(validation_messages=[])
+
+        result = asyncio.run(
+            send_event("G-TEST123", "client-1", _EVENTS, confirm=True)
+        )
+
+        self.assertTrue(result["sent"])
+        self.assertFalse(result["dry_run"])
+        self.assertEqual(result["events_sent"], 1)
+        urls = [call.args[0] for call in mock_post.call_args_list]
+        self.assertEqual(
+            urls,
+            [measurement._DEBUG_COLLECT_URL, measurement._COLLECT_URL],
+        )
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_confirm_blocked_by_validation_failure(self, mock_post):
+        """Tests that invalid payloads are never sent, even confirmed."""
+        mock_post.return_value = _mock_response(
+            validation_messages=[{"description": "bad"}]
+        )
+
+        result = asyncio.run(
+            send_event("G-TEST123", "client-1", _EVENTS, confirm=True)
+        )
+
+        self.assertFalse(result["sent"])
+        urls = [call.args[0] for call in mock_post.call_args_list]
+        self.assertEqual(urls, [measurement._DEBUG_COLLECT_URL])
+
+    @patch.dict("os.environ", _SECRET_ENV)
+    @patch("analytics_mcp.tools.measurement.httpx.post")
+    def test_optional_fields_in_payload(self, mock_post):
+        """Tests that optional payload fields are passed through."""
+        mock_post.return_value = _mock_response(validation_messages=[])
+
+        asyncio.run(
+            send_event(
+                "G-TEST123",
+                "client-1",
+                _EVENTS,
+                user_id="user-9",
+                timestamp_micros=1700000000000000,
+                user_properties={"plan": {"value": "premium"}},
+                non_personalized_ads=True,
+            )
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["user_id"], "user-9")
+        self.assertEqual(payload["timestamp_micros"], 1700000000000000)
+        self.assertEqual(
+            payload["user_properties"], {"plan": {"value": "premium"}}
+        )
+        self.assertTrue(payload["non_personalized_ads"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the reporting metadata tools."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1beta
+
+from analytics_mcp.tools.reporting.metadata import (
+    get_custom_dimensions_and_metrics,
+    get_metadata,
+)
+
+
+def _sample_metadata() -> data_v1beta.Metadata:
+    """Returns a Metadata proto with standard and custom entries."""
+    return data_v1beta.Metadata(
+        name="properties/12345/metadata",
+        dimensions=[
+            data_v1beta.DimensionMetadata(
+                api_name="country",
+                ui_name="Country",
+                description="The country from which activity originated.",
+                category="Geography",
+                custom_definition=False,
+            ),
+            data_v1beta.DimensionMetadata(
+                api_name="customEvent:plan_type",
+                ui_name="Plan type",
+                description="Custom event-scoped dimension.",
+                category="Custom",
+                custom_definition=True,
+            ),
+        ],
+        metrics=[
+            data_v1beta.MetricMetadata(
+                api_name="activeUsers",
+                ui_name="Active users",
+                description="The number of distinct active users.",
+                category="User",
+                custom_definition=False,
+            ),
+        ],
+    )
+
+
+class TestGetMetadata(unittest.TestCase):
+    """Test cases for get_metadata."""
+
+    @patch("analytics_mcp.tools.reporting.metadata.create_data_api_client")
+    def test_returns_full_catalog(self, mock_create_client):
+        """Tests that the full catalog is returned, not just custom."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.get_metadata.return_value = _sample_metadata()
+
+        result = asyncio.run(get_metadata(12345))
+
+        mock_client.get_metadata.assert_called_once_with(
+            name="properties/12345/metadata"
+        )
+        dimension_names = [d["api_name"] for d in result["dimensions"]]
+        self.assertIn("country", dimension_names)
+        self.assertIn("customEvent:plan_type", dimension_names)
+        self.assertEqual(result["metrics"][0]["api_name"], "activeUsers")
+        self.assertEqual(result["dimensions"][0]["category"], "Geography")
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(get_metadata("bogus"))
+
+
+class TestGetCustomDimensionsAndMetrics(unittest.TestCase):
+    """Test cases for get_custom_dimensions_and_metrics."""
+
+    @patch("analytics_mcp.tools.reporting.metadata.create_data_api_client")
+    def test_returns_only_custom_definitions(self, mock_create_client):
+        """Tests that only custom definitions are returned."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.get_metadata.return_value = _sample_metadata()
+
+        result = asyncio.run(get_custom_dimensions_and_metrics(12345))
+
+        self.assertEqual(len(result["custom_dimensions"]), 1)
+        self.assertEqual(
+            result["custom_dimensions"][0]["api_name"],
+            "customEvent:plan_type",
+        )
+        self.assertEqual(result["custom_metrics"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pivot_test.py
+++ b/tests/pivot_test.py
@@ -1,0 +1,214 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the run_pivot_report tool."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1beta
+
+from analytics_mcp.tools.reporting.pivot import (
+    _run_pivot_report_description,
+    run_pivot_report,
+)
+
+_BASE_ARGS = {
+    "date_ranges": [{"start_date": "7daysAgo", "end_date": "today"}],
+    "dimensions": ["country", "deviceCategory"],
+    "metrics": ["activeUsers"],
+    "pivots": [
+        {"field_names": ["country"], "limit": 10},
+        {"field_names": ["deviceCategory"], "limit": 5},
+    ],
+}
+
+
+class TestRunPivotReport(unittest.TestCase):
+    """Test cases for run_pivot_report."""
+
+    @patch("analytics_mcp.tools.reporting.pivot.create_data_api_client")
+    def test_builds_request(self, mock_create_client):
+        """Tests that the request proto is built correctly."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_pivot_report.return_value = (
+            data_v1beta.RunPivotReportResponse()
+        )
+
+        asyncio.run(run_pivot_report(12345, **_BASE_ARGS))
+
+        request = mock_client.run_pivot_report.call_args.args[0]
+        self.assertIsInstance(request, data_v1beta.RunPivotReportRequest)
+        self.assertEqual(request.property, "properties/12345")
+        self.assertEqual(
+            [d.name for d in request.dimensions],
+            ["country", "deviceCategory"],
+        )
+        self.assertEqual([m.name for m in request.metrics], ["activeUsers"])
+        self.assertEqual(len(request.pivots), 2)
+        self.assertEqual(list(request.pivots[0].field_names), ["country"])
+        self.assertEqual(request.pivots[0].limit, 10)
+        self.assertEqual(
+            list(request.pivots[1].field_names), ["deviceCategory"]
+        )
+        self.assertFalse(request.keep_empty_rows)
+
+    @patch("analytics_mcp.tools.reporting.pivot.create_data_api_client")
+    def test_optional_fields(self, mock_create_client):
+        """Tests that optional fields are set when provided."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_pivot_report.return_value = (
+            data_v1beta.RunPivotReportResponse()
+        )
+
+        asyncio.run(
+            run_pivot_report(
+                12345,
+                **_BASE_ARGS,
+                dimension_filter={
+                    "filter": {
+                        "field_name": "country",
+                        "string_filter": {"value": "Japan"},
+                    }
+                },
+                currency_code="USD",
+                keep_empty_rows=True,
+                return_property_quota=True,
+            )
+        )
+
+        request = mock_client.run_pivot_report.call_args.args[0]
+        self.assertEqual(request.dimension_filter.filter.field_name, "country")
+        self.assertEqual(request.currency_code, "USD")
+        self.assertTrue(request.keep_empty_rows)
+        self.assertTrue(request.return_property_quota)
+
+    def test_empty_pivots_raises(self):
+        """Tests that an empty pivots list raises a ValueError."""
+        args = dict(_BASE_ARGS, pivots=[])
+        with self.assertRaises(ValueError):
+            asyncio.run(run_pivot_report(12345, **args))
+
+    def test_pivot_missing_field_names_raises(self):
+        """Tests that a pivot without field_names raises a ValueError."""
+        args = dict(_BASE_ARGS, pivots=[{"limit": 5}])
+        with self.assertRaises(ValueError):
+            asyncio.run(run_pivot_report(12345, **args))
+
+    @patch("analytics_mcp.tools.reporting.pivot.create_data_api_client")
+    def test_converts_response(self, mock_create_client):
+        """Tests that the proto response is converted to a dict."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.run_pivot_report.return_value = (
+            data_v1beta.RunPivotReportResponse(
+                aggregates=[],
+                rows=[
+                    data_v1beta.Row(
+                        dimension_values=[
+                            data_v1beta.DimensionValue(value="Japan")
+                        ],
+                        metric_values=[data_v1beta.MetricValue(value="42")],
+                    )
+                ],
+            )
+        )
+
+        result = asyncio.run(run_pivot_report(12345, **_BASE_ARGS))
+
+        self.assertEqual(
+            result["rows"][0]["dimension_values"][0]["value"], "Japan"
+        )
+        self.assertEqual(result["rows"][0]["metric_values"][0]["value"], "42")
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(run_pivot_report("bogus", **_BASE_ARGS))
+
+
+class TestDescription(unittest.TestCase):
+    """Test cases for the tool description."""
+
+    def test_description_includes_hints(self):
+        """Tests that the description contains pivot hints."""
+        description = _run_pivot_report_description()
+        self.assertIn("pivots", description)
+        self.assertIn("field_names", description)
+        self.assertIn("date_range", description)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestBatchRunPivotReports(unittest.TestCase):
+    """Test cases for batch_run_pivot_reports."""
+
+    @patch("analytics_mcp.tools.reporting.pivot.create_data_api_client")
+    def test_builds_batch_request(self, mock_create_client):
+        """Tests that the batch request proto is built correctly."""
+        from analytics_mcp.tools.reporting.pivot import (
+            batch_run_pivot_reports,
+        )
+
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.batch_run_pivot_reports.return_value = (
+            data_v1beta.BatchRunPivotReportsResponse()
+        )
+
+        asyncio.run(
+            batch_run_pivot_reports(12345, requests=[_BASE_ARGS, _BASE_ARGS])
+        )
+
+        request = mock_client.batch_run_pivot_reports.call_args.args[0]
+        self.assertIsInstance(request, data_v1beta.BatchRunPivotReportsRequest)
+        self.assertEqual(request.property, "properties/12345")
+        self.assertEqual(len(request.requests), 2)
+        self.assertEqual(request.requests[0].property, "properties/12345")
+        self.assertEqual(len(request.requests[0].pivots), 2)
+
+    def test_empty_requests_raises(self):
+        """Tests that an empty requests list raises a ValueError."""
+        from analytics_mcp.tools.reporting.pivot import (
+            batch_run_pivot_reports,
+        )
+
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_pivot_reports(12345, requests=[]))
+
+    def test_too_many_requests_raises(self):
+        """Tests that more than 5 requests raises a ValueError."""
+        from analytics_mcp.tools.reporting.pivot import (
+            batch_run_pivot_reports,
+        )
+
+        with self.assertRaises(ValueError):
+            asyncio.run(
+                batch_run_pivot_reports(12345, requests=[_BASE_ARGS] * 6)
+            )
+
+    def test_request_missing_pivots_raises(self):
+        """Tests that a request without pivots raises a ValueError."""
+        from analytics_mcp.tools.reporting.pivot import (
+            batch_run_pivot_reports,
+        )
+
+        bad = {k: v for k, v in _BASE_ARGS.items() if k != "pivots"}
+        with self.assertRaises(ValueError):
+            asyncio.run(batch_run_pivot_reports(12345, requests=[bad]))

--- a/tests/quotas_test.py
+++ b/tests/quotas_test.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the get_property_quotas tool."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from google.analytics import data_v1alpha
+
+from analytics_mcp.tools.reporting.quotas import get_property_quotas
+
+
+class TestGetPropertyQuotas(unittest.TestCase):
+    """Test cases for get_property_quotas."""
+
+    @patch("analytics_mcp.tools.reporting.quotas.create_data_api_alpha_client")
+    def test_returns_quota_snapshot(self, mock_create_client):
+        """Tests that the quota snapshot is fetched and converted."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        snapshot = data_v1alpha.PropertyQuotasSnapshot(
+            name="properties/12345/propertyQuotasSnapshot",
+            core_property_quota=data_v1alpha.PropertyQuota(
+                tokens_per_day=data_v1alpha.QuotaStatus(
+                    consumed=100, remaining=199900
+                ),
+            ),
+        )
+        mock_client.get_property_quotas_snapshot.return_value = snapshot
+
+        result = asyncio.run(get_property_quotas(12345))
+
+        request = mock_client.get_property_quotas_snapshot.call_args.kwargs[
+            "request"
+        ]
+        self.assertEqual(
+            request.name, "properties/12345/propertyQuotasSnapshot"
+        )
+        self.assertEqual(
+            result["core_property_quota"]["tokens_per_day"]["consumed"], 100
+        )
+        self.assertEqual(
+            result["core_property_quota"]["tokens_per_day"]["remaining"],
+            199900,
+        )
+
+    def test_invalid_property_id_raises(self):
+        """Tests that an invalid property ID raises a ValueError."""
+        with self.assertRaises(ValueError):
+            asyncio.run(get_property_quotas("bogus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -68,3 +68,45 @@ class TestUtils(unittest.TestCase):
             msg="Resource name with more than 2 components should fail",
         ):
             utils.construct_property_rn("properties/123/abc")
+
+    def test_construct_account_rn(self):
+        """Tests construct_account_rn using valid input."""
+        self.assertEqual(
+            utils.construct_account_rn(12345),
+            "accounts/12345",
+            "Numeric account ID should be considered valid",
+        )
+        self.assertEqual(
+            utils.construct_account_rn("12345"),
+            "accounts/12345",
+            "Numeric account ID as string should be considered valid",
+        )
+        self.assertEqual(
+            utils.construct_account_rn(" 12345  "),
+            "accounts/12345",
+            "Whitespace around account ID should be considered valid",
+        )
+        self.assertEqual(
+            utils.construct_account_rn("accounts/12345"),
+            "accounts/12345",
+            "Full resource name should be considered valid",
+        )
+
+    def test_construct_account_rn_invalid_input(self):
+        """Tests that construct_account_rn raises a ValueError for invalid input."""
+        with self.assertRaises(ValueError, msg="None should fail"):
+            utils.construct_account_rn(None)
+        with self.assertRaises(ValueError, msg="Empty string should fail"):
+            utils.construct_account_rn("")
+        with self.assertRaises(
+            ValueError, msg="Non-numeric string should fail"
+        ):
+            utils.construct_account_rn("abc")
+        with self.assertRaises(
+            ValueError, msg="Resource name without ID should fail"
+        ):
+            utils.construct_account_rn("accounts/")
+        with self.assertRaises(
+            ValueError, msg="Property resource name should fail"
+        ):
+            utils.construct_account_rn("properties/123")


### PR DESCRIPTION
Closes #48368. Removes the duplicate `import traceback` inside the except block. `py_compile` clean.